### PR TITLE
Use a different data structure for storing graph state

### DIFF
--- a/orchestra/exceptions.py
+++ b/orchestra/exceptions.py
@@ -40,8 +40,29 @@ class ContextValueError(Exception):
     pass
 
 
+class InvalidTask(Exception):
+
+    def __init__(self, task_id):
+        Exception.__init__(self, 'Task "%s" does not exist.' % task_id)
+
+
+class InvalidTaskTransition(Exception):
+
+    def __init__(self, src, dest):
+        Exception.__init__(self, 'Task transition from "%s" to "%s" does not exist.' % (src, dest))
+
+
+class AmbiguousTaskTransition(Exception):
+
+    def __init__(self, src, dest):
+        message = 'More than one task transitions found from "%s" to "%s".' % (src, dest)
+        Exception.__init__(self, message)
+
+
 class InvalidState(Exception):
-    pass
+
+    def __init__(self, value):
+        Exception.__init__(self, 'State "%s" is not valid.' % value)
 
 
 class InvalidStateTransition(Exception):

--- a/orchestra/expressions/functions/workflow.py
+++ b/orchestra/expressions/functions/workflow.py
@@ -24,9 +24,18 @@ def _get_current_task(context):
 
 
 def task_state_(context, task_id):
-    task_states = context['__task_states'] or {}
+    task_flow = context['__flow'] or {}
+    task_flow_item_idx = task_flow['tasks'].get(task_id)
 
-    return task_states.get(task_id, states.UNSET)
+    if task_flow_item_idx is None:
+        return states.UNSET
+
+    task_flow_item = task_flow['sequence'][task_flow_item_idx]
+
+    if task_flow_item is None:
+        return states.UNSET
+
+    return task_flow_item.get('state', states.UNSET)
 
 
 def succeeded_(context):

--- a/orchestra/expressions/jinja.py
+++ b/orchestra/expressions/jinja.py
@@ -76,7 +76,7 @@ class JinjaEvaluator(base.Evaluator):
             ctx[name] = partial(func, ctx['_'])
 
         if isinstance(data, dict):
-            ctx['__task_states'] = data.get('__task_states')
+            ctx['__flow'] = data.get('__flow')
             ctx['__current_task'] = data.get('__current_task')
 
         return ctx

--- a/orchestra/expressions/yql.py
+++ b/orchestra/expressions/yql.py
@@ -60,7 +60,7 @@ class YAQLEvaluator(base.Evaluator):
     def contextualize(cls, data):
         ctx = cls._root_ctx.create_child_context()
         ctx['$'] = data or {}
-        ctx['__task_states'] = ctx['$'].get('__task_states')
+        ctx['__flow'] = ctx['$'].get('__flow')
         ctx['__current_task'] = ctx['$'].get('__current_task')
 
         return ctx

--- a/orchestra/graphing.py
+++ b/orchestra/graphing.py
@@ -30,38 +30,47 @@ LOG = logging.getLogger(__name__)
 @six.add_metaclass(abc.ABCMeta)
 class WorkflowGraph(object):
 
-    def __init__(self, graph=None):
+    def __init__(self, graph=None, flow=None):
+        # self._graph is the graph model for the workflow. The tracking of workflow and task
+        # progress and state is separate from the graph model. There are use cases where tasks
+        # may be cycled and states overwritten. Therefore, use the var _flow to track progress
+        # and states.
         self._graph = graph if graph else nx.MultiDiGraph()
 
+        # self._flow tracks the workflow and task progress, states, and flow.
+        self._flow = flow if flow else dict()
+
+        # self.flow['state'] tracks the state of the workflow execution.
+        if not self._flow.get('state'):
+            self._flow['state'] = None
+
+        # self._flow['sequence'] tracks the progress and state of task executions.
+        if not self._flow.get('sequence'):
+            self._flow['sequence'] = list()
+
+        # self._flow['tasks'] references current instance of tasks.
+        if not self._flow.get('tasks'):
+            self._flow['tasks'] = dict()
+
     def serialize(self):
-        return json_graph.adjacency_data(self._graph)
+        return {
+            'graph': json_graph.adjacency_data(self._graph),
+            'flow': copy.deepcopy(self._flow)
+        }
 
     @classmethod
     def deserialize(cls, data):
-        g = json_graph.adjacency_graph(data, directed=True, multigraph=True)
+        g = json_graph.adjacency_graph(copy.deepcopy(data['graph']), directed=True, multigraph=True)
+        f = copy.deepcopy(data['flow'])
 
-        return cls(graph=g)
-
-    @property
-    def state(self):
-        return self._graph.graph.get('state', None)
-
-    @state.setter
-    def state(self, value):
-        if value not in states.ALL_STATES:
-            raise ValueError('State "%s" is not valid.', value)
-
-        if not states.is_transition_valid(self.state, value):
-            raise exc.InvalidStateTransition(self.state, value)
-
-        self._graph.graph['state'] = value
+        return cls(graph=g, flow=f)
 
     def has_task(self, task_id):
         return self._graph.has_node(task_id)
 
     def get_task(self, task_id):
         if not self.has_task(task_id):
-            raise Exception('Task "%s" does not exist.', task_id)
+            raise exc.InvalidTask(task_id)
 
         task = {'id': task_id}
         task.update(copy.deepcopy(self._graph.node[task_id]))
@@ -83,32 +92,10 @@ class WorkflowGraph(object):
 
     def update_task(self, task_id, **kwargs):
         if not self.has_task(task_id):
-            raise Exception('Task "%s" does not exist.', task_id)
+            raise exc.InvalidTask(task_id)
 
-        # Check if change in task state is valid.
-        old_state = self._graph.node[task_id].get('state', None)
-        new_state = kwargs.get('state', None)
-
-        if not states.is_transition_valid(old_state, new_state):
-            raise exc.InvalidStateTransition(old_state, new_state)
-
-        # Update the task attributes.
         for key, value in six.iteritems(kwargs):
             self._graph.node[task_id][key] = value
-
-    def reset_task(self, task_id):
-        if not self.has_task(task_id):
-            raise Exception('Task "%s" does not exist.', task_id)
-
-        task_attrs = {}
-
-        if 'name' in self._graph.node[task_id]:
-            task_attrs['name'] = self._graph.node[task_id]['name']
-
-        if 'barrier' in self._graph.node[task_id]:
-            task_attrs['barrier'] = self._graph.node[task_id]['barrier']
-
-        self._graph.node[task_id] = task_attrs
 
     def get_start_tasks(self):
         tasks = [
@@ -118,49 +105,45 @@ class WorkflowGraph(object):
 
         return sorted(tasks, key=lambda x: x['name'])
 
-    def get_next_tasks(self, task_id, context=None):
-        task = self.get_task(task_id)
+    def get_next_tasks(self, task_id):
+        task_flow_item = self.get_task_flow_item(task_id)
 
-        if task['state'] not in states.COMPLETED_STATES:
+        if not task_flow_item or task_flow_item.get('state') not in states.COMPLETED_STATES:
             return []
 
-        context = dict_utils.merge_dicts(
-            context or {},
-            {'__task_states': self.get_task_attributes('state')},
-            overwrite=True
-        )
+        next_tasks = []
+        outbounds = self.get_next_transitions(task_id)
 
-        tasks = []
-        outbounds = []
+        for next_seq in outbounds:
+            next_task_id, seq_key = next_seq[1], next_seq[2]
+            task_transition_id = next_task_id + '__' + str(seq_key)
 
-        for seq in self.get_next_transitions(task_id):
-            evaluated_criteria = [
-                expressions.evaluate(criterion, context)
-                for criterion in seq[3]['criteria']
-            ]
+            # Evaluate if outbound criteria is satisfied.
+            if not task_flow_item.get(task_transition_id):
+                continue
 
-            if all(evaluated_criteria):
-                outbounds.append(seq)
-
-        for seq in outbounds:
-            next_task_id, seq_key, attrs = seq[1], seq[2], seq[3]
-
-            if not attrs.get('satisfied', False):
-                self.update_transition(task_id, next_task_id, key=seq_key, satisfied=True)
-
+            # Evaluate if the next task has a barrier waiting for other tasks to complete.
             if self.has_barrier(next_task_id):
                 barrier = self.get_barrier(next_task_id)
                 inbounds = self.get_prev_transitions(next_task_id)
-                satisfied = [s for s in inbounds if s[3].get('satisfied')]
+
                 barrier = len(inbounds) if barrier == '*' else barrier
+                satisfied = []
+
+                for prev_seq in inbounds:
+                    prev_task_flow_item = self.get_task_flow_item(prev_seq[0])
+
+                    if prev_task_flow_item:
+                        prev_task_transition_id = prev_seq[1] + '__' + str(prev_seq[2])
+                        satisfied.append(prev_task_flow_item.get(prev_task_transition_id))
 
                 if len(satisfied) < barrier:
                     continue
 
             next_task = self.get_task(next_task_id)
-            tasks.append({'id': next_task_id, 'name': next_task['name']})
+            next_tasks.append({'id': next_task_id, 'name': next_task['name']})
 
-        return sorted(tasks, key=lambda x: x['name'])
+        return sorted(next_tasks, key=lambda x: x['name'])
 
     def has_transition(self, source, destination, criteria=None):
         return [
@@ -178,10 +161,10 @@ class WorkflowGraph(object):
         ]
 
         if not seqs:
-            raise Exception('Task transition does not exist.')
+            raise exc.InvalidTaskTransition(source, destination)
 
         if len(seqs) > 1:
-            raise Exception('More than one task transitions found.')
+            raise exc.AmbiguousTaskTransition(source, destination)
 
         return seqs[0]
 
@@ -198,7 +181,7 @@ class WorkflowGraph(object):
         seqs = self.has_transition(source, destination, criteria)
 
         if len(seqs) > 1:
-            raise Exception('More than one task transitions found.')
+            raise exc.AmbiguousTaskTransition(source, destination)
 
         if not seqs:
             self._graph.add_edge(source, destination, criteria=criteria)
@@ -236,3 +219,73 @@ class WorkflowGraph(object):
 
     def in_cycle(self, task_id):
         return [c for c in nx.simple_cycles(self._graph) if task_id in c]
+
+    @property
+    def state(self):
+        return self._flow.get('state', None)
+
+    @state.setter
+    def state(self, value):
+        if not states.is_valid(value):
+            raise exc.InvalidState(value)
+
+        if not states.is_transition_valid(self.state, value):
+            raise exc.InvalidStateTransition(self.state, value)
+
+        self._flow['state'] = value
+
+    @property
+    def sequence(self):
+        return self._flow['sequence']
+
+    def get_task_flow_idx(self, task_id):
+        return self._flow['tasks'].get(task_id)
+
+    def get_task_flow_item(self, task_id):
+        flow_idx = self.get_task_flow_idx(task_id)
+
+        return self.sequence[flow_idx] if flow_idx is not None else None
+
+    def add_task_flow_item(self, task_id):
+        if not self.has_task(task_id):
+            raise exc.InvalidTask(task_id)
+
+        task_flow_item = {'id': task_id}
+        self.sequence.append(task_flow_item)
+        self._flow['tasks'][task_id] = len(self.sequence) - 1
+
+        return task_flow_item
+
+    def update_task_flow_item(self, task_id, state, context=None):
+        if not states.is_valid(state):
+            raise exc.InvalidState(state)
+
+        task_flow_item = self.get_task_flow_item(task_id)
+
+        # Create new task flow entry if it does not exist.
+        if not task_flow_item:
+            task_flow_item = self.add_task_flow_item(task_id)
+
+        # If task is already completed and in cycle, then create new task flow entry.
+        if self.in_cycle(task_id) and task_flow_item.get('state') in states.COMPLETED_STATES:
+            task_flow_item = self.add_task_flow_item(task_id)
+
+        # Check if the task state change is valid.
+        if not states.is_transition_valid(task_flow_item.get('state'), state):
+            raise exc.InvalidStateTransition(task_flow_item.get('state'), state)
+
+        task_flow_item['state'] = state
+
+        # Evaluate task transitions if task is in completed state.
+        if state in states.COMPLETED_STATES:
+            # Setup context for evaluating expressions in task transition criteria.
+            ctx = dict_utils.merge_dicts(context or {}, {'__flow': self._flow}, overwrite=True)
+
+            # Iterate thru each outbound task transitions.
+            for t in self.get_next_transitions(task_id):
+                criteria = t[3].get('criteria') or []
+                evaluated_criteria = [expressions.evaluate(c, ctx) for c in criteria]
+                task_transition_id = t[1] + '__' + str(t[2])
+                task_flow_item[task_transition_id] = all(evaluated_criteria)
+
+        return task_flow_item

--- a/orchestra/states.py
+++ b/orchestra/states.py
@@ -106,6 +106,10 @@ VALID_STATE_TRANSITION_MAP = {
 }
 
 
+def is_valid(state):
+    return (state is None or state in ALL_STATES)
+
+
 def is_transition_valid(old_state, new_state):
     if old_state is None:
         old_state = 'null'
@@ -114,13 +118,13 @@ def is_transition_valid(old_state, new_state):
         new_state = 'null'
 
     if old_state not in ALL_STATES:
-        raise exc.InvalidState('State "%s" is not valid.', old_state)
+        raise exc.InvalidState(old_state)
 
     if old_state not in VALID_STATE_TRANSITION_MAP:
-        raise exc.InvalidState('State "%s" is not in transition map.', old_state)
+        raise exc.InvalidState(old_state)
 
     if new_state not in ALL_STATES:
-        raise exc.InvalidState('State "%s" is not valid.', new_state)
+        raise exc.InvalidState(new_state)
 
     if old_state == new_state or new_state in VALID_STATE_TRANSITION_MAP[old_state]:
         return True

--- a/orchestra/tests/unit/graphing/test_task_flow.py
+++ b/orchestra/tests/unit/graphing/test_task_flow.py
@@ -1,0 +1,198 @@
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orchestra import graphing
+from orchestra import exceptions as exc
+from orchestra import states
+from orchestra.tests.unit import base
+
+
+class WorkflowGraphTaskFlowTest(base.WorkflowGraphTest):
+
+    def _add_tasks(self, wf_graph):
+        for i in range(1, 6):
+            wf_graph.add_task('task' + str(i))
+
+    def _add_transitions(self, wf_graph):
+        wf_graph.add_transition('task1', 'task2')
+        wf_graph.add_transition('task1', 'task5')
+        wf_graph.add_transition('task2', 'task3')
+        wf_graph.add_transition('task3', 'task4')
+        wf_graph.add_transition('task4', 'task2')
+
+    def _prep_graph(self, wf_graph):
+        self._add_tasks(wf_graph)
+        self._add_transitions(wf_graph)
+
+    def test_get_set_graph_state(self):
+        wf_graph = graphing.WorkflowGraph()
+        self._prep_graph(wf_graph)
+
+        self.assertIsNone(wf_graph.state)
+
+        wf_graph.state = states.RUNNING
+        self.assertEqual(wf_graph.state, states.RUNNING)
+
+    def test_get_set_bad_graph_state(self):
+        wf_graph = graphing.WorkflowGraph()
+        self._prep_graph(wf_graph)
+
+        self.assertRaises(exc.InvalidState, wf_graph.state, 'foobar')
+        self.assertIsNone(wf_graph.state)
+
+    def test_add_task_flow_item(self):
+        wf_graph = graphing.WorkflowGraph()
+        self._prep_graph(wf_graph)
+
+        wf_graph.add_task_flow_item('task1')
+        expected_task_flow_item = {'id': 'task1'}
+
+        self.assertEqual(wf_graph.get_task_flow_idx('task1'), 0)
+        self.assertDictEqual(wf_graph.get_task_flow_item('task1'), expected_task_flow_item)
+
+    def test_update_task_flow_item(self):
+        wf_graph = graphing.WorkflowGraph()
+        self._prep_graph(wf_graph)
+
+        wf_graph.update_task_flow_item('task1', states.RUNNING)
+        expected_task_flow_item = {'id': 'task1', 'state': 'running'}
+
+        self.assertEqual(wf_graph.get_task_flow_idx('task1'), 0)
+        self.assertDictEqual(wf_graph.get_task_flow_item('task1'), expected_task_flow_item)
+
+        wf_graph.update_task_flow_item('task1', states.SUCCEEDED, context={'var1': 'foobar'})
+
+        expected_task_flow_item = {
+            'id': 'task1',
+            'state': 'succeeded',
+            'task2__0': True,
+            'task5__0': True
+        }
+
+        self.assertEqual(wf_graph.get_task_flow_idx('task1'), 0)
+        self.assertDictEqual(wf_graph.get_task_flow_item('task1'), expected_task_flow_item)
+
+    def test_update_task_flow_item_for_nonexistent_task(self):
+        wf_graph = graphing.WorkflowGraph()
+        self._prep_graph(wf_graph)
+
+        self.assertRaises(
+            exc.InvalidTask,
+            wf_graph.update_task_flow_item,
+            'task999',
+            states.RUNNING
+        )
+
+    def test_update_invalid_state_to_task_flow_item(self):
+        wf_graph = graphing.WorkflowGraph()
+        self._prep_graph(wf_graph)
+
+        self.assertRaises(
+            exc.InvalidState,
+            wf_graph.update_task_flow_item,
+            'task1',
+            'foobar'
+        )
+
+        self.assertRaises(
+            exc.InvalidStateTransition,
+            wf_graph.update_task_flow_item,
+            'task1',
+            states.SUCCEEDED
+        )
+
+    def test_add_sequence_to_task_flow(self):
+        wf_graph = graphing.WorkflowGraph()
+        self._prep_graph(wf_graph)
+
+        # Update progress of task1 to task flow.
+        wf_graph.update_task_flow_item('task1', states.RUNNING)
+        expected_task_flow_item = {'id': 'task1', 'state': 'running'}
+
+        self.assertEqual(wf_graph.get_task_flow_idx('task1'), 0)
+        self.assertDictEqual(wf_graph.get_task_flow_item('task1'), expected_task_flow_item)
+
+        wf_graph.update_task_flow_item('task1', states.SUCCEEDED, context={'var1': 'foobar'})
+
+        expected_task_flow_item = {
+            'id': 'task1',
+            'state': 'succeeded',
+            'task2__0': True,
+            'task5__0': True
+        }
+
+        self.assertEqual(wf_graph.get_task_flow_idx('task1'), 0)
+        self.assertDictEqual(wf_graph.get_task_flow_item('task1'), expected_task_flow_item)
+
+        expected_sequence = [
+            {'id': 'task1', 'state': 'succeeded', 'task2__0': True, 'task5__0': True}
+        ]
+
+        self.assertListEqual(wf_graph.sequence, expected_sequence)
+
+        # Update progress of task2 to task flow.
+        wf_graph.update_task_flow_item('task2', states.RUNNING)
+        expected_task_flow_item = {'id': 'task2', 'state': 'running'}
+
+        self.assertEqual(wf_graph.get_task_flow_idx('task2'), 1)
+        self.assertDictEqual(wf_graph.get_task_flow_item('task2'), expected_task_flow_item)
+
+        wf_graph.update_task_flow_item('task2', states.SUCCEEDED, context={'var1': 'foobar'})
+        expected_task_flow_item = {'id': 'task2', 'state': 'succeeded', 'task3__0': True}
+
+        self.assertEqual(wf_graph.get_task_flow_idx('task2'), 1)
+        self.assertDictEqual(wf_graph.get_task_flow_item('task2'), expected_task_flow_item)
+
+        expected_sequence = [
+            {'id': 'task1', 'state': 'succeeded', 'task2__0': True, 'task5__0': True},
+            {'id': 'task2', 'state': 'succeeded', 'task3__0': True}
+        ]
+
+        self.assertListEqual(wf_graph.sequence, expected_sequence)
+
+    def test_add_cycle_to_task_flow(self):
+        wf_graph = graphing.WorkflowGraph()
+        self._prep_graph(wf_graph)
+
+        # Check that there's a cycle in the graph.
+        self.assertFalse(wf_graph.in_cycle('task1'))
+        self.assertTrue(wf_graph.in_cycle('task2'))
+        self.assertTrue(wf_graph.in_cycle('task3'))
+        self.assertTrue(wf_graph.in_cycle('task4'))
+
+        # Add a cycle to the task flow.
+        wf_graph.update_task_flow_item('task1', states.RUNNING)
+        wf_graph.update_task_flow_item('task1', states.SUCCEEDED)
+        wf_graph.update_task_flow_item('task2', states.RUNNING)
+        wf_graph.update_task_flow_item('task2', states.SUCCEEDED)
+        wf_graph.update_task_flow_item('task3', states.RUNNING)
+        wf_graph.update_task_flow_item('task3', states.SUCCEEDED)
+        wf_graph.update_task_flow_item('task4', states.RUNNING)
+        wf_graph.update_task_flow_item('task4', states.SUCCEEDED)
+        wf_graph.update_task_flow_item('task2', states.RUNNING)
+
+        # Check the reference pointer. Task2 points to the latest instance.
+        self.assertEqual(wf_graph.get_task_flow_idx('task1'), 0)
+        self.assertEqual(wf_graph.get_task_flow_idx('task2'), 4)
+        self.assertEqual(wf_graph.get_task_flow_idx('task3'), 2)
+        self.assertEqual(wf_graph.get_task_flow_idx('task4'), 3)
+
+        # Check sequence.
+        expected_sequence = [
+            {'id': 'task1', 'state': 'succeeded', 'task2__0': True, 'task5__0': True},
+            {'id': 'task2', 'state': 'succeeded', 'task3__0': True},
+            {'id': 'task3', 'state': 'succeeded', 'task4__0': True},
+            {'id': 'task4', 'state': 'succeeded', 'task2__0': True},
+            {'id': 'task2', 'state': 'running'},
+        ]
+
+        self.assertListEqual(wf_graph.sequence, expected_sequence)


### PR DESCRIPTION
Workflow graph can have cycles. In such case, a task state will be overwritten. This patch separates the execution graph from the execution state. There's a new task flow dictionary that keeps track of task execution sequence and which state is current for tasks in cycle. Additional methods are included to work with the task flow dictionary.