### PR TITLE
Fix exception type for invalid state transition

### DIFF
--- a/orchestra/states.py
+++ b/orchestra/states.py
@@ -120,11 +120,11 @@ def is_transition_valid(old_state, new_state):
     if old_state not in ALL_STATES:
         raise exc.InvalidState(old_state)
 
-    if old_state not in VALID_STATE_TRANSITION_MAP:
-        raise exc.InvalidState(old_state)
-
     if new_state not in ALL_STATES:
         raise exc.InvalidState(new_state)
+
+    if old_state not in VALID_STATE_TRANSITION_MAP:
+        raise exc.InvalidStateTransition(old_state, new_state)
 
     if old_state == new_state or new_state in VALID_STATE_TRANSITION_MAP[old_state]:
         return True

--- a/orchestra/tests/unit/test_states.py
+++ b/orchestra/tests/unit/test_states.py
@@ -33,7 +33,7 @@ class FailedStateTransitionTest(unittest.TestCase):
         self.assertRaises(exc.InvalidState, states.is_transition_valid, states.UNSET, 'foobar')
 
     def test_invalid_state_transition(self):
-        self.assertRaises(exc.InvalidState, states.is_transition_valid, 'mock', None)
+        self.assertRaises(exc.InvalidStateTransition, states.is_transition_valid, 'mock', None)
 
 
 class StateTransitionTest(unittest.TestCase):


### PR DESCRIPTION
Fix the exception type being raise for a case of invalid state transition where the original state is not in the transition map.