### PR TITLE
Fix case where original state not present in transition map

### DIFF
--- a/orchestra/states.py
+++ b/orchestra/states.py
@@ -124,7 +124,7 @@ def is_transition_valid(old_state, new_state):
         raise exc.InvalidState(new_state)
 
     if old_state not in VALID_STATE_TRANSITION_MAP:
-        raise exc.InvalidStateTransition(old_state, new_state)
+        return False
 
     if old_state == new_state or new_state in VALID_STATE_TRANSITION_MAP[old_state]:
         return True

--- a/orchestra/tests/unit/test_states.py
+++ b/orchestra/tests/unit/test_states.py
@@ -32,8 +32,8 @@ class FailedStateTransitionTest(unittest.TestCase):
         self.assertRaises(exc.InvalidState, states.is_transition_valid, 'foobar', states.REQUESTED)
         self.assertRaises(exc.InvalidState, states.is_transition_valid, states.UNSET, 'foobar')
 
-    def test_invalid_state_transition(self):
-        self.assertRaises(exc.InvalidStateTransition, states.is_transition_valid, 'mock', None)
+    def test_original_state_not_in_transition_map(self):
+        self.assertFalse(states.is_transition_valid('mock', None))
 
 
 class StateTransitionTest(unittest.TestCase):


### PR DESCRIPTION
Return false instead of throwing an exception when the original state is not present in the transition map.