### PR TITLE
Resolve inline parameters in action of task and publish of task transition

### DIFF
--- a/orchestra/specs/native/v1/models.py
+++ b/orchestra/specs/native/v1/models.py
@@ -19,6 +19,7 @@ from orchestra.expressions import base as expr
 from orchestra.specs import types
 from orchestra.specs.native.v1 import base
 from orchestra.utils import dictionary as dx
+from orchestra.utils import parameters as args_utils
 
 
 LOG = logging.getLogger(__name__)
@@ -62,6 +63,14 @@ class TaskTransitionSpec(base.Spec):
     _context_inputs = [
         'publish'
     ]
+
+    def __init__(self, *args, **kwargs):
+        super(TaskTransitionSpec, self).__init__(*args, **kwargs)
+
+        publish_spec = getattr(self, 'publish', None)
+
+        if publish_spec and isinstance(publish_spec, six.string_types):
+            self.publish = args_utils.parse_inline_params(publish_spec or str())
 
 
 class TaskTransitionSequenceSpec(base.SequenceSpec):
@@ -109,6 +118,16 @@ class TaskSpec(base.Spec):
         'input',
         'next'
     ]
+
+    def __init__(self, *args, **kwargs):
+        super(TaskSpec, self).__init__(*args, **kwargs)
+
+        action_spec = getattr(self, 'action', str())
+        input_spec = args_utils.parse_inline_params(action_spec)
+
+        if input_spec:
+            self.action = action_spec[:action_spec.index(' ')]
+            self.input = input_spec
 
     def has_join(self):
         return hasattr(self, 'join') and self.join

--- a/orchestra/tests/fixtures/workflows/native/sequential.yaml
+++ b/orchestra/tests/fixtures/workflows/native/sequential.yaml
@@ -13,15 +13,11 @@ output:
 
 tasks:
   task1:
-    action: core.echo
-    input:
-      message: <% $.name %>
+    action: core.echo message=<% $.name %>
     next:
       - when: <% succeeded() %>
-        publish:
-          greeting: <% result() %> 
-        do:
-          - task2
+        publish: greeting=<% result() %> 
+        do: task2
   task2:
     action: core.echo
     input:
@@ -30,8 +26,7 @@ tasks:
       - when: <% succeeded() %>
         publish:
           greeting: <% $.greeting %>, <% result() %>
-        do: task3
+        do:
+          - task3
   task3:
-    action: core.echo
-    input:
-      message: <% $.greeting %>
+    action: core.echo message=<% $.greeting %>

--- a/orchestra/tests/unit/specs/native/test_workflow_spec.py
+++ b/orchestra/tests/unit/specs/native/test_workflow_spec.py
@@ -40,6 +40,7 @@ class WorkflowSpecTest(base.OrchestraWorkflowSpecTest):
 
         self.assertIsInstance(task1, specs.TaskSpec)
         self.assertEqual(task1.action, 'core.echo')
+        self.assertDictEqual(task1.input, {'message': '<% $.name %>'})
 
         task1_transition_seqs = getattr(task1, 'next')
 
@@ -58,9 +59,14 @@ class WorkflowSpecTest(base.OrchestraWorkflowSpecTest):
             '<% succeeded() %>'
         )
 
-        self.assertListEqual(
+        self.assertDictEqual(
+            getattr(task1_transition_seqs[0], 'publish'),
+            {'greeting': '<% result() %>'}
+        )
+
+        self.assertEqual(
             getattr(task1_transition_seqs[0], 'do'),
-            ['task2']
+            'task2'
         )
 
         # Verify model for task2.
@@ -68,6 +74,7 @@ class WorkflowSpecTest(base.OrchestraWorkflowSpecTest):
 
         self.assertIsInstance(task2, specs.TaskSpec)
         self.assertEqual(task2.action, 'core.echo')
+        self.assertDictEqual(task2.input, {'message': 'All your base are belong to us!'})
 
         task2_transition_seqs = getattr(task2, 'next')
 
@@ -86,9 +93,14 @@ class WorkflowSpecTest(base.OrchestraWorkflowSpecTest):
             '<% succeeded() %>'
         )
 
-        self.assertEqual(
+        self.assertDictEqual(
+            getattr(task2_transition_seqs[0], 'publish'),
+            {'greeting': '<% $.greeting %>, <% result() %>'}
+        )
+
+        self.assertListEqual(
             getattr(task2_transition_seqs[0], 'do'),
-            'task3'
+            ['task3']
         )
 
         # Verify model for task3.

--- a/orchestra/tests/unit/specs/native/test_workflow_spec_validate.py
+++ b/orchestra/tests/unit/specs/native/test_workflow_spec_validate.py
@@ -283,11 +283,11 @@ class WorkflowSpecValidationTest(base.OrchestraWorkflowSpecTest):
             ],
             'context': [
                 {
-                    'spec_path': 'tasks.task1.action',
+                    'spec_path': 'tasks.task1.input',
                     'expression': '<% $.foobar %>',
                     'message': 'Variable "foobar" is referenced before assignment.',
                     'type': 'yaql',
-                    'schema_path': 'properties.tasks.patternProperties.^\\w+$.properties.action'
+                    'schema_path': 'properties.tasks.patternProperties.^\\w+$.properties.input'
                 }
             ],
             'syntax': [


### PR DESCRIPTION
When the definition is loaded into the task and task transition spec, separates the inline parameters that is in a string into the type defined in the respective specs.