### PR TITLE
Fix publish for terminal tasks

### DIFF
--- a/orchestra/specs/native/__init__.py
+++ b/orchestra/specs/native/__init__.py
@@ -12,6 +12,7 @@
 
 from orchestra.specs.native import v1
 from orchestra.specs.native.v1 import instantiate, deserialize
+from orchestra.specs.native.v1 import get_reserved_task_names
 from orchestra.specs.native.v1 import TaskMappingSpec
 from orchestra.specs.native.v1 import TaskSpec
 from orchestra.specs.native.v1 import TaskTransitionSequenceSpec
@@ -23,6 +24,7 @@ VERSION = v1.VERSION
 __all__ = [
     instantiate.__name__,
     deserialize.__name__,
+    get_reserved_task_names.__name__,
     WorkflowSpec.__name__,
     TaskMappingSpec.__name__,
     TaskSpec.__name__,

--- a/orchestra/specs/native/v1/__init__.py
+++ b/orchestra/specs/native/v1/__init__.py
@@ -12,6 +12,7 @@
 
 from orchestra.specs.native.v1 import base
 from orchestra.specs.native.v1.models import instantiate, deserialize
+from orchestra.specs.native.v1.models import get_reserved_task_names
 from orchestra.specs.native.v1.models import TaskMappingSpec
 from orchestra.specs.native.v1.models import TaskSpec
 from orchestra.specs.native.v1.models import TaskTransitionSequenceSpec
@@ -23,6 +24,7 @@ VERSION = base.Spec.get_version()
 __all__ = [
     instantiate.__name__,
     deserialize.__name__,
+    get_reserved_task_names.__name__,
     WorkflowSpec.__name__,
     TaskMappingSpec.__name__,
     TaskSpec.__name__,

--- a/orchestra/specs/native/v1/models.py
+++ b/orchestra/specs/native/v1/models.py
@@ -24,6 +24,10 @@ from orchestra.utils import parameters as args_utils
 
 LOG = logging.getLogger(__name__)
 
+RESERVED_TASK_NAMES = [
+    'noop'
+]
+
 
 def instantiate(definition):
     return WorkflowSpec(definition)
@@ -71,6 +75,11 @@ class TaskTransitionSpec(base.Spec):
 
         if publish_spec and isinstance(publish_spec, six.string_types):
             self.publish = args_utils.parse_inline_params(publish_spec or str())
+
+        do_spec = getattr(self, 'do', None)
+
+        if not do_spec:
+            self.do = 'noop'
 
 
 class TaskTransitionSequenceSpec(base.SequenceSpec):
@@ -176,6 +185,9 @@ class TaskMappingSpec(base.MappingSpec):
     }
 
     def get_task(self, task_name):
+        if task_name in RESERVED_TASK_NAMES:
+            return TaskSpec({'name': task_name})
+
         return self[task_name]
 
     def get_next_tasks(self, task_name, *args, **kwargs):

--- a/orchestra/tests/fixtures/workflows/native/sequential.yaml
+++ b/orchestra/tests/fixtures/workflows/native/sequential.yaml
@@ -30,3 +30,6 @@ tasks:
           - task3
   task3:
     action: core.echo message=<% $.greeting %>
+    next:
+      - when: <% succeeded() %>
+        publish: greeting=<% result() %>

--- a/orchestra/tests/unit/composition/native/test_workflow_basic.py
+++ b/orchestra/tests/unit/composition/native/test_workflow_basic.py
@@ -30,6 +30,9 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                 },
                 {
                     'id': 'task3'
+                },
+                {
+                    'id': 'noop'
                 }
             ],
             'adjacency': [
@@ -43,6 +46,13 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                 [
                     {
                         'id': 'task3',
+                        'key': 0,
+                        'criteria': ['<% succeeded() %>']
+                    }
+                ],
+                [
+                    {
+                        'id': 'noop',
                         'key': 0,
                         'criteria': ['<% succeeded() %>']
                     }
@@ -69,6 +79,10 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                 {
                     'id': 'task3',
                     'name': 'task3'
+                },
+                {
+                    'id': 'noop',
+                    'name': 'noop'
                 }
             ],
             'adjacency': [
@@ -82,6 +96,13 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                 [
                     {
                         'id': 'task3',
+                        'key': 0,
+                        'criteria': ['<% succeeded() %>']
+                    }
+                ],
+                [
+                    {
+                        'id': 'noop',
                         'key': 0,
                         'criteria': ['<% succeeded() %>']
                     }

--- a/orchestra/tests/unit/conducting/native/test_workflow_basic.py
+++ b/orchestra/tests/unit/conducting/native/test_workflow_basic.py
@@ -21,7 +21,8 @@ class BasicWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
         expected_task_seq = [
             'task1',
             'task2',
-            'task3'
+            'task3',
+            'noop'
         ]
 
         mock_results = [

--- a/orchestra/tests/unit/specs/native/test_workflow_spec.py
+++ b/orchestra/tests/unit/specs/native/test_workflow_spec.py
@@ -108,7 +108,34 @@ class WorkflowSpecTest(base.OrchestraWorkflowSpecTest):
 
         self.assertIsInstance(task3, specs.TaskSpec)
         self.assertEqual(task3.action, 'core.echo')
-        self.assertIsNone(getattr(task3, 'next'))
+        self.assertDictEqual(task3.input, {'message': '<% $.greeting %>'})
+
+        task3_transition_seqs = getattr(task3, 'next')
+
+        self.assertIsInstance(
+            task3_transition_seqs,
+            specs.TaskTransitionSequenceSpec
+        )
+
+        self.assertIsInstance(
+            task3_transition_seqs[0],
+            specs.TaskTransitionSpec
+        )
+
+        self.assertEqual(
+            getattr(task3_transition_seqs[0], 'when'),
+            '<% succeeded() %>'
+        )
+
+        self.assertDictEqual(
+            getattr(task3_transition_seqs[0], 'publish'),
+            {'greeting': '<% result() %>'}
+        )
+
+        self.assertEqual(
+            getattr(task3_transition_seqs[0], 'do'),
+            'noop'
+        )
 
     def test_basic_spec_serialization(self):
         wf_name = 'sequential'

--- a/orchestra/tests/unit/utils/test_parameters.py
+++ b/orchestra/tests/unit/utils/test_parameters.py
@@ -73,3 +73,15 @@ class InlineParametersTest(unittest.TestCase):
         }
 
         self.assertDictEqual(params.parse_inline_params(s), d)
+
+    def test_parse_empty_string(self):
+        self.assertDictEqual(params.parse_inline_params(str()), {})
+
+    def test_parse_null_type(self):
+        self.assertDictEqual(params.parse_inline_params(None), {})
+
+    def test_parse_other_types(self):
+        self.assertDictEqual(params.parse_inline_params(123), {})
+        self.assertDictEqual(params.parse_inline_params(True), {})
+        self.assertDictEqual(params.parse_inline_params([1, 2, 3]), {})
+        self.assertDictEqual(params.parse_inline_params({'a': 123}), {})

--- a/orchestra/utils/parameters.py
+++ b/orchestra/utils/parameters.py
@@ -12,6 +12,7 @@
 
 import json
 import re
+import six
 
 from orchestra.expressions import base as expr
 
@@ -43,6 +44,9 @@ REGEX_INLINE_PARAMS = '([\w]+)=(%s)' % '|'.join(REGEX_INLINE_PARAM_VARIATIONS)
 
 def parse_inline_params(s):
     params = {}
+
+    if s is None or not isinstance(s, six.string_types) or s == str():
+        return params
 
     for k, v in re.findall(REGEX_INLINE_PARAMS, s):
         # Remove leading and trailing whitespaces.


### PR DESCRIPTION
Terminal tasks with transition criteria, publish, and no next task are allowed but with no next task, the transition in the workflow graph is invalid and the publish is unreachable. This patch defaults the transition with a noop task, a reserved task name with special function.