### PR TITLE
Support expression evaluation in task action and input

### DIFF
--- a/orchestra/specs/base.py
+++ b/orchestra/specs/base.py
@@ -140,6 +140,9 @@ class Spec(object):
                 if re.match(pattern, name) and value:
                     setattr(self, name, spec_cls(value, member=True))
 
+    def copy(self):
+        return self.deserialize(self.serialize())
+
     def serialize(self):
         value = {
             'catalog': self.get_catalog(),

--- a/orchestra/tests/unit/base.py
+++ b/orchestra/tests/unit/base.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import abc
+import copy
 import six
 from six.moves import queue
 import unittest
@@ -130,6 +131,32 @@ class WorkflowComposerTest(WorkflowGraphTest, WorkflowSpecTest):
 
 @six.add_metaclass(abc.ABCMeta)
 class WorkflowConductorTest(WorkflowComposerTest):
+
+    def format_task_item(self, task_name, task_init_ctx, task_spec, task_id=None):
+        return {
+            'id': task_id or task_name,
+            'name': task_name,
+            'ctx': task_init_ctx,
+            'spec': task_spec
+        }
+
+    def assert_task_list(self, actual, expected):
+        """
+        The conductor.get_start_tasks and conductor.get_next_tasks make copies of the
+        task specs and render expressions in the task action and task input. So comparing
+        the task specs will not match. In order to match in unit tests. This method is
+        used to serialize the task specs and compare the lists.
+        """
+        actual_copy = copy.deepcopy(actual)
+        expected_copy = copy.deepcopy(expected)
+
+        for task in actual_copy:
+            task['spec'] = task['spec'].serialize()
+
+        for task in expected_copy:
+            task['spec'] = task['spec'].serialize()
+
+        self.assertListEqual(actual_copy, expected_copy)
 
     def assert_conducting_sequences(self, wf_name, expected_task_seq, inputs=None,
                                     mock_states=None, mock_results=None,

--- a/orchestra/tests/unit/conducting/test_task_rendering.py
+++ b/orchestra/tests/unit/conducting/test_task_rendering.py
@@ -1,0 +1,67 @@
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orchestra import conducting
+from orchestra.specs import native as specs
+from orchestra import states
+from orchestra.tests.unit import base
+
+
+class WorkflowConductorTaskRenderingTest(base.WorkflowConductorTest):
+
+    def _prep_conductor(self, inputs=None, state=None):
+        wf_def = """
+        version: 1.0
+
+        description: A basic sequential workflow.
+
+        input:
+          - action_name
+          - action_input
+
+        tasks:
+          task1:
+            action: <% $.action_name %>
+            input: <% $.action_input %>
+            next:
+              - do: task2
+          task2:
+            action: core.noop
+        """
+
+        spec = specs.WorkflowSpec(wf_def)
+
+        conductor = conducting.WorkflowConductor(spec)
+
+        if inputs:
+            conductor = conducting.WorkflowConductor(spec, **inputs)
+        else:
+            conductor = conducting.WorkflowConductor(spec)
+
+        if state:
+            conductor.set_workflow_state(state)
+
+        return conductor
+
+    def test_runtime_rendering(self):
+        action_name = 'core.echo'
+        action_input = {'message': 'All your base are belong to us!'}
+        inputs = {'action_name': action_name, 'action_input': action_input}
+        conductor = self._prep_conductor(inputs, state=states.RUNNING)
+
+        task1_spec = conductor.spec.tasks.get_task('task1').copy()
+        task1_spec.action = action_name
+        task1_spec.input = action_input
+
+        expected = [self.format_task_item('task1', inputs, task1_spec)]
+        actual = conductor.get_start_tasks()
+        self.assert_task_list(actual, expected)

--- a/orchestra/tests/unit/conducting/test_workflow_conductor_branching.py
+++ b/orchestra/tests/unit/conducting/test_workflow_conductor_branching.py
@@ -75,9 +75,10 @@ class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
         conductor.update_task_flow_entry(task_name, states.SUCCEEDED)
         expected_txsn_ctx = {'task3__0': {'srcs': [0, 1], 'value': {'var1': 'xyz', 'var2': 123}}}
         self.assertDictEqual(conductor.get_task_transition_contexts('task2'), expected_txsn_ctx)
+        next_task_spec = conductor.spec.tasks.get_task(next_task_name)
         expected_ctx_value = {'var1': 'xyz', 'var2': 123}
-        expected_tasks = [{'id': next_task_name, 'name': next_task_name, 'ctx': expected_ctx_value}]
-        self.assertListEqual(conductor.get_next_tasks(task_name), expected_tasks)
+        expected_tasks = [self.format_task_item(next_task_name, expected_ctx_value, next_task_spec)]
+        self.assert_task_list(conductor.get_next_tasks(task_name), expected_tasks)
 
         # Conduct task3 and check merged context.
         task_name = 'task3'
@@ -152,8 +153,10 @@ class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
         conductor.update_task_flow_entry(task_name, states.SUCCEEDED)
         expected_txsn_ctx = {'task3__0': {'srcs': [], 'value': {}}}
         self.assertDictEqual(conductor.get_task_transition_contexts('task2'), expected_txsn_ctx)
-        expected_tasks = [{'id': next_task_name, 'name': next_task_name, 'ctx': {}}]
-        self.assertListEqual(conductor.get_next_tasks(task_name), expected_tasks)
+        next_task_spec = conductor.spec.tasks.get_task(next_task_name)
+        expected_ctx_value = {}
+        expected_tasks = [self.format_task_item(next_task_name, expected_ctx_value, next_task_spec)]
+        self.assert_task_list(conductor.get_next_tasks(task_name), expected_tasks)
 
         # Conduct task3 and check merged context.
         task_name = 'task3'
@@ -230,8 +233,10 @@ class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
         conductor.update_task_flow_entry(task_name, states.SUCCEEDED)
         expected_txsn_ctx = {'task3__0': {'srcs': [], 'value': inputs}}
         self.assertDictEqual(conductor.get_task_transition_contexts('task2'), expected_txsn_ctx)
-        expected_tasks = [{'id': next_task_name, 'name': next_task_name, 'ctx': inputs}]
-        self.assertListEqual(conductor.get_next_tasks(task_name), expected_tasks)
+        next_task_spec = conductor.spec.tasks.get_task(next_task_name)
+        expected_ctx_value = inputs
+        expected_tasks = [self.format_task_item(next_task_name, expected_ctx_value, next_task_spec)]
+        self.assert_task_list(conductor.get_next_tasks(task_name), expected_tasks)
 
         # Conduct task3 and check merged context.
         task_name = 'task3'
@@ -295,8 +300,9 @@ class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
         expected_ctx_value = {'var1': 'xyz'}
         expected_txsn_ctx = {'task2__0': {'srcs': [0], 'value': expected_ctx_value}}
         self.assertDictEqual(conductor.get_task_transition_contexts(task_name), expected_txsn_ctx)
-        expected_tasks = [{'id': next_task_name, 'name': next_task_name, 'ctx': expected_ctx_value}]
-        self.assertListEqual(conductor.get_next_tasks(task_name), expected_tasks)
+        next_task_spec = conductor.spec.tasks.get_task(next_task_name)
+        expected_tasks = [self.format_task_item(next_task_name, expected_ctx_value, next_task_spec)]
+        self.assert_task_list(conductor.get_next_tasks(task_name), expected_tasks)
 
         # Conduct task3 and check context.
         task_name = 'task3'
@@ -306,8 +312,9 @@ class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
         expected_ctx_value = {'var2': 123}
         expected_txsn_ctx = {'task4__0': {'srcs': [1], 'value': expected_ctx_value}}
         self.assertDictEqual(conductor.get_task_transition_contexts(task_name), expected_txsn_ctx)
-        expected_tasks = [{'id': next_task_name, 'name': next_task_name, 'ctx': expected_ctx_value}]
-        self.assertListEqual(conductor.get_next_tasks(task_name), expected_tasks)
+        next_task_spec = conductor.spec.tasks.get_task(next_task_name)
+        expected_tasks = [self.format_task_item(next_task_name, expected_ctx_value, next_task_spec)]
+        self.assert_task_list(conductor.get_next_tasks(task_name), expected_tasks)
 
         # Conduct task2 and check context.
         task_name = 'task2'


### PR DESCRIPTION
When getting start tasks or next tasks from the workflow conductor, evaluate expressions in task action and input and return rendered values.