### PR TITLE
Fix expression evaluation for string concatenation

### DIFF
--- a/orchestra/expressions/jinja.py
+++ b/orchestra/expressions/jinja.py
@@ -146,11 +146,10 @@ class JinjaEvaluator(base.Evaluator):
                 # and cast it to string. When StrictUndefined is cast to str below, this will
                 # raise an exception with error description.
                 if not isinstance(result, jinja2.runtime.StrictUndefined):
-                    output = (
-                        output.replace(expr, str(result))
-                        if len(exprs) > 1 or block_exprs
-                        else result
-                    )
+                    if len(exprs) > 1 or block_exprs or len(output) > len(expr):
+                        output = output.replace(expr, str(result))
+                    else:
+                        output = result
 
             # Evaluate jinja block(s) after inline expressions are evaluated.
             if block_exprs and isinstance(output, six.string_types):

--- a/orchestra/expressions/yql.py
+++ b/orchestra/expressions/yql.py
@@ -109,7 +109,10 @@ class YAQLEvaluator(base.Evaluator):
                 if isinstance(result, six.string_types):
                     result = cls.evaluate(result, data)
 
-                output = output.replace(expr, str(result)) if len(exprs) > 1 else result
+                if len(exprs) > 1 or len(output) > len(expr):
+                    output = output.replace(expr, str(result))
+                else:
+                    output = result
 
         except KeyError as e:
             raise YaqlEvaluationException(

--- a/orchestra/tests/unit/expressions/test_facade_jinja_evaluate.py
+++ b/orchestra/tests/unit/expressions/test_facade_jinja_evaluate.py
@@ -19,11 +19,10 @@ from orchestra.expressions import base as expressions
 class JinjaFacadeEvaluationTest(unittest.TestCase):
 
     def test_basic_eval(self):
-        expr = '{{ _.foo }}'
-
         data = {'foo': 'bar'}
 
-        self.assertEqual('bar', expressions.evaluate(expr, data))
+        self.assertEqual('bar', expressions.evaluate('{{ _.foo }}', data))
+        self.assertEqual('foobar', expressions.evaluate('foo{{ _.foo }}', data))
 
     def test_basic_eval_undefined(self):
         expr = '{{ _.foo }}'
@@ -106,7 +105,8 @@ class JinjaFacadeEvaluationTest(unittest.TestCase):
     def test_eval_list(self):
         expr = [
             '{{ _.foo }}',
-            '{{ _.marco }}'
+            '{{ _.marco }}',
+            'foo{{ _.foo }}'
         ]
 
         data = {
@@ -114,7 +114,7 @@ class JinjaFacadeEvaluationTest(unittest.TestCase):
             'marco': 'polo'
         }
 
-        self.assertListEqual(['bar', 'polo'], expressions.evaluate(expr, data))
+        self.assertListEqual(['bar', 'polo', 'foobar'], expressions.evaluate(expr, data))
 
     def test_eval_list_of_list(self):
         expr = [
@@ -158,7 +158,8 @@ class JinjaFacadeEvaluationTest(unittest.TestCase):
     def test_eval_dict(self):
         expr = {
             'foo': '{{ _.bar }}',
-            '{{ _.marco }}': 'polo'
+            '{{ _.marco }}': 'polo',
+            'foobar': 'foo{{ _.bar }}'
         }
 
         data = {
@@ -168,7 +169,8 @@ class JinjaFacadeEvaluationTest(unittest.TestCase):
 
         expected = {
             'foo': 'bar',
-            'marco': 'polo'
+            'marco': 'polo',
+            'foobar': 'foobar'
         }
 
         self.assertDictEqual(expected, expressions.evaluate(expr, data))

--- a/orchestra/tests/unit/expressions/test_facade_yaql_evaluate.py
+++ b/orchestra/tests/unit/expressions/test_facade_yaql_evaluate.py
@@ -19,11 +19,10 @@ from orchestra.expressions import base as expressions
 class YAQLFacadeEvaluationTest(unittest.TestCase):
 
     def test_basic_eval(self):
-        expr = '<% $.foo %>'
-
         data = {'foo': 'bar'}
 
-        self.assertEqual('bar', expressions.evaluate(expr, data))
+        self.assertEqual('bar', expressions.evaluate('<% $.foo %>', data))
+        self.assertEqual('foobar', expressions.evaluate('foo<% $.foo %>', data))
 
     def test_basic_eval_undefined(self):
         expr = '<% $.foo %>'
@@ -90,7 +89,8 @@ class YAQLFacadeEvaluationTest(unittest.TestCase):
     def test_eval_list(self):
         expr = [
             '<% $.foo %>',
-            '<% $.marco %>'
+            '<% $.marco %>',
+            'foo<% $.foo %>'
         ]
 
         data = {
@@ -98,7 +98,7 @@ class YAQLFacadeEvaluationTest(unittest.TestCase):
             'marco': 'polo'
         }
 
-        self.assertListEqual(['bar', 'polo'], expressions.evaluate(expr, data))
+        self.assertListEqual(['bar', 'polo', 'foobar'], expressions.evaluate(expr, data))
 
     def test_eval_list_of_list(self):
         expr = [
@@ -142,7 +142,8 @@ class YAQLFacadeEvaluationTest(unittest.TestCase):
     def test_eval_dict(self):
         expr = {
             'foo': '<% $.bar %>',
-            '<% $.marco %>': 'polo'
+            '<% $.marco %>': 'polo',
+            'foobar': 'foo<% $.bar %>'
         }
 
         data = {
@@ -152,7 +153,8 @@ class YAQLFacadeEvaluationTest(unittest.TestCase):
 
         expected = {
             'foo': 'bar',
-            'marco': 'polo'
+            'marco': 'polo',
+            'foobar': 'foobar'
         }
 
         self.assertDictEqual(expected, expressions.evaluate(expr, data))


### PR DESCRIPTION
Fix evaluation when the statement contains expression and some other text. Before the patch, after evaluation, the statement is replaced with only the result of the expression evaluation and the other text is lost.