### PR TITLE
Make input and output singular in serialization data

### DIFF
--- a/orchestra/conducting.py
+++ b/orchestra/conducting.py
@@ -101,8 +101,8 @@ class WorkflowConductor(object):
             'spec': self.spec.serialize(),
             'graph': self.graph.serialize(),
             'flow': self.flow.serialize(),
-            'inputs': self.get_workflow_input(),
-            'outputs': self.get_workflow_output(),
+            'input': self.get_workflow_input(),
+            'output': self.get_workflow_output(),
             'errors': copy.deepcopy(self.errors),
             'state': self.get_workflow_state()
         }
@@ -115,8 +115,8 @@ class WorkflowConductor(object):
         graph = graphing.WorkflowGraph.deserialize(data['graph'])
         state = data['state']
         flow = TaskFlow.deserialize(data['flow'])
-        inputs = copy.deepcopy(data['inputs'])
-        outputs = copy.deepcopy(data['outputs'])
+        inputs = copy.deepcopy(data['input'])
+        outputs = copy.deepcopy(data['output'])
         errors = copy.deepcopy(data['errors'])
 
         instance = cls(spec)

--- a/orchestra/tests/unit/conducting/test_workflow_conductor.py
+++ b/orchestra/tests/unit/conducting/test_workflow_conductor.py
@@ -109,8 +109,8 @@ class WorkflowConductorTest(base.WorkflowConductorTest):
         expected_data = {
             'spec': conductor.spec.serialize(),
             'graph': conductor.graph.serialize(),
-            'inputs': {},
-            'outputs': None,
+            'input': {},
+            'output': None,
             'state': None,
             'errors': [],
             'flow': {
@@ -143,8 +143,8 @@ class WorkflowConductorTest(base.WorkflowConductorTest):
         expected_data = {
             'spec': conductor.spec.serialize(),
             'graph': conductor.graph.serialize(),
-            'inputs': inputs,
-            'outputs': None,
+            'input': inputs,
+            'output': None,
             'state': None,
             'errors': [],
             'flow': {
@@ -179,8 +179,8 @@ class WorkflowConductorTest(base.WorkflowConductorTest):
         expected_data = {
             'spec': conductor.spec.serialize(),
             'graph': conductor.graph.serialize(),
-            'inputs': inputs,
-            'outputs': None,
+            'input': inputs,
+            'output': None,
             'state': None,
             'errors': [],
             'flow': {
@@ -221,8 +221,8 @@ class WorkflowConductorTest(base.WorkflowConductorTest):
             'graph': conductor.graph.serialize(),
             'state': conductor.get_workflow_state(),
             'flow': conductor.flow.serialize(),
-            'inputs': conductor.get_workflow_input(),
-            'outputs': conductor.get_workflow_output(),
+            'input': conductor.get_workflow_input(),
+            'output': conductor.get_workflow_output(),
             'errors': conductor.errors
         }
 


### PR DESCRIPTION
Make the naming of the input and output attributes consistent. Use singular in public interfaces and data.