### PR TITLE
Refactor schema and rendering of vars

### DIFF
--- a/orchestra/specs/types.py
+++ b/orchestra/specs/types.py
@@ -140,3 +140,10 @@ UNIQUE_STRING_OR_ONE_KEY_DICT_LIST = {
     "uniqueItems": True,
     "minItems": 1
 }
+
+UNIQUE_ONE_KEY_DICT_LIST = {
+    "type": "array",
+    "items": ONE_KEY_DICT,
+    "uniqueItems": True,
+    "minItems": 1
+}

--- a/orchestra/tests/fixtures/workflows/native/branching.yaml
+++ b/orchestra/tests/fixtures/workflows/native/branching.yaml
@@ -4,25 +4,25 @@ description: A basic workflow that branches out.
 
 tasks:
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task2, task4
 
   # branch 1
   task2:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task3
   task3:
-    action: std.noop
+    action: core.noop
 
   # branch 2
   task4:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task5
   task5:
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/fixtures/workflows/native/cycle.yaml
+++ b/orchestra/tests/fixtures/workflows/native/cycle.yaml
@@ -7,24 +7,24 @@ input:
 
 tasks:
   prep:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task1
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task2
   task2:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task3
   task3:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() and $.count < 2 %>
         publish:
-          count: <% $.count + 1 %>
+          - count: <% $.count + 1 %>
         do: task1

--- a/orchestra/tests/fixtures/workflows/native/cycles.yaml
+++ b/orchestra/tests/fixtures/workflows/native/cycles.yaml
@@ -7,40 +7,40 @@ input:
 
 tasks:
   prep:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task1
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         publish:
-          proceed: false
+          - proceed: false
         do: task2
   task2:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() and not $.proceed %>
         do: task3
       - when: <% succeeded() and $.proceed %>
         do: task5
   task3:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task4
   task4:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         publish:
-          proceed: true
+          - proceed: true
         do: task2
   task5:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() and $.count < 2 %>
         publish:
-          count: <% $.count + 1 %>
+          - count: <% $.count + 1 %>
         do: task1

--- a/orchestra/tests/fixtures/workflows/native/decision.yaml
+++ b/orchestra/tests/fixtures/workflows/native/decision.yaml
@@ -9,7 +9,7 @@ input:
 
 tasks:
   t1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() and $.which = "a" %>
         do: a
@@ -18,8 +18,8 @@ tasks:
       - when: <% succeeded() and not $.which in list(a, b) %>
         do: c
   a:
-    action: std.noop
+    action: core.noop
   b:
-    action: std.noop
+    action: core.noop
   c:
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/fixtures/workflows/native/join-count.yaml
+++ b/orchestra/tests/fixtures/workflows/native/join-count.yaml
@@ -4,43 +4,43 @@ description: A basic workflow that demonstrate join on count requirement.
 
 tasks:
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task2, task4, task6
 
   # branch 1
   task2:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task3
   task3:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task8
 
   # branch 2
   task4:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task5
   task5:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task8
 
   # branch 3
   task6:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
   task7:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task8
@@ -48,4 +48,4 @@ tasks:
   # converge branches
   task8:
     join: 2
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/fixtures/workflows/native/join.yaml
+++ b/orchestra/tests/fixtures/workflows/native/join.yaml
@@ -4,32 +4,32 @@ description: A basic workflow that demonstrate branching and join.
 
 tasks:
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task2, task4
 
   # branch 1
   task2:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task3
 
   task3:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task6
 
   # branch 2
   task4:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task5
   task5:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task6
@@ -37,9 +37,9 @@ tasks:
   # converge branch 1 and 2
   task6:
     join: all
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
   task7:
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/fixtures/workflows/native/parallel.yaml
+++ b/orchestra/tests/fixtures/workflows/native/parallel.yaml
@@ -5,28 +5,28 @@ description: A set of parallel workflows.
 tasks:
   # Branch 1
   task1:
-    action: std.noop
+    action: core.noop
     next:
        - when: <% succeeded() %>
          do: task2
   task2:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task3
   task3:
-    action: std.noop
+    action: core.noop
 
   # Branch 2
   task4:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task5
   task5:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task6
   task6:
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/fixtures/workflows/native/sequential.yaml
+++ b/orchestra/tests/fixtures/workflows/native/sequential.yaml
@@ -6,10 +6,10 @@ input:
   - name
 
 vars:
-  greeting: null 
+  - greeting: null 
 
 output:
-  greeting: <% $.greeting %>
+  - greeting: <% $.greeting %>
 
 tasks:
   task1:
@@ -25,7 +25,7 @@ tasks:
     next:
       - when: <% succeeded() %>
         publish:
-          greeting: <% $.greeting %>, <% result() %>
+          - greeting: <% $.greeting %>, <% result() %>
         do:
           - task3
   task3:

--- a/orchestra/tests/fixtures/workflows/native/split.yaml
+++ b/orchestra/tests/fixtures/workflows/native/split.yaml
@@ -7,41 +7,41 @@ description: >
 
 tasks:
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task2, task3
 
   # branch 1
   task2:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task4
 
   # branch 2
   task3:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task4
 
   # split branch
   task4:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task5, task6
   task5:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
   task6:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
   task7:
     join: all
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/fixtures/workflows/native/splits-join.yaml
+++ b/orchestra/tests/fixtures/workflows/native/splits-join.yaml
@@ -6,47 +6,47 @@ description: >
 
 tasks:
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task2, task3, task8
 
   # branch 1
   task2:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task4
 
   # branch 2
   task3:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task4
 
   # split branch
   task4:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task5, task6
   task5:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
   task6:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
   task7:
     join: all
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task8
   task8:
     join: all
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/fixtures/workflows/native/splits-nested.yaml
+++ b/orchestra/tests/fixtures/workflows/native/splits-nested.yaml
@@ -8,58 +8,58 @@ description: >
 
 tasks:
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task2, task3
 
   # branch 1
   task2:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task4
 
   # branch 2
   task3:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task4
 
   # split branch
   task4:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task5, task6
   task5:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
   task6:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
 
   # nested split
   task7:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task8, task9
   task8:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task10
   task9:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task10
   task10:
     join: all
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/fixtures/workflows/native/splits.yaml
+++ b/orchestra/tests/fixtures/workflows/native/splits.yaml
@@ -6,46 +6,46 @@ description: >
 
 tasks:
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task2, task3, task8
 
   # branch 1
   task2:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task4
 
   # branch 2
   task3:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task4
 
   # split branch
   task4:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task5, task6
   task5:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
   task6:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
   task7:
     join: all
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task8
   task8:
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/fixtures/workflows/native/task-on-complete.yaml
+++ b/orchestra/tests/fixtures/workflows/native/task-on-complete.yaml
@@ -4,7 +4,7 @@ description: A basic workflow that demonstrates next handler.
 
 tasks:
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - when: <% succeeded() %>
         do: task2
@@ -12,8 +12,8 @@ tasks:
         do: task3
       - do: task4
   task2:
-    action: std.noop
+    action: core.noop
   task3:
-    action: std.noop
+    action: core.noop
   task4:
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/fixtures/workflows/native/task-transitions-split.yaml
+++ b/orchestra/tests/fixtures/workflows/native/task-transitions-split.yaml
@@ -6,7 +6,7 @@ description: >
 
 tasks:
   task1:
-    action: std.noop
+    action: core.noop
     next:
       - do: task2
       - when: <% failed() %>
@@ -14,4 +14,4 @@ tasks:
       - when: <% succeeded() %>
         do: task2
   task2:
-    action: std.noop
+    action: core.noop

--- a/orchestra/tests/unit/conducting/test_workflow_conductor_branching.py
+++ b/orchestra/tests/unit/conducting/test_workflow_conductor_branching.py
@@ -31,7 +31,7 @@ class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
             next:
               - when: <% succeeded() %>
                 publish:
-                  var1: 'xyz'
+                  - var1: 'xyz'
                 do: task3
 
           # branch 2
@@ -40,7 +40,7 @@ class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
             next:
               - when: <% succeeded() %>
                 publish:
-                  var2: 123
+                  - var2: 123
                 do: task3
 
           # adjoining branch
@@ -50,7 +50,7 @@ class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
             next:
               - when: <% succeeded() %>
                 publish:
-                  var3: True
+                  - var3: True
                 do: task4
           task4:
             action: core.noop
@@ -271,7 +271,7 @@ class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
             next:
               - when: <% succeeded() %>
                 publish:
-                  var1: 'xyz'
+                  - var1: 'xyz'
                 do: task2
           task2:
             action: core.noop
@@ -282,7 +282,7 @@ class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
             next:
               - when: <% succeeded() %>
                 publish:
-                  var2: 123
+                  - var2: 123
                 do: task4
           task4:
             action: core.noop

--- a/orchestra/tests/unit/conducting/test_workflow_conductor_data_flow.py
+++ b/orchestra/tests/unit/conducting/test_workflow_conductor_data_flow.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orchestra import conducting
+from orchestra.specs import native as specs
+from orchestra import states
+from orchestra.tests.unit import base
+
+
+class WorkflowConductorDataFlowTest(base.WorkflowConductorTest):
+
+    def _prep_conductor(self, inputs=None, state=None):
+        wf_def = """
+        version: 1.0
+
+        description: A basic sequential workflow.
+
+        input:
+          - a1
+          - b1: <% $.a1 %>
+
+        vars:
+          - a2: <% $.b1 %>
+          - b2: <% $.a2 %>
+
+        output:
+          - a5: <% $.b4 %>
+          - b5: <% $.a5 %>
+
+        tasks:
+          task1:
+            action: core.noop
+            next:
+              - when: <% succeeded() %>
+                publish:
+                  - a3: <% $.b2 %>
+                  - b3: <% $.a3 %>
+                do: task2
+          task2:
+            action: core.noop
+            next:
+              - when: <% succeeded() %>
+                publish: a4=<% $.b3 %> b4=<% $.a4 %>
+                do: task3
+          task3:
+            action: core.noop
+        """
+
+        spec = specs.WorkflowSpec(wf_def)
+        self.assertDictEqual(spec.inspect(), {})
+
+        if inputs:
+            conductor = conducting.WorkflowConductor(spec, **inputs)
+            self.assertDictEqual(conductor.get_workflow_input(), inputs)
+        else:
+            conductor = conducting.WorkflowConductor(spec)
+
+        if state:
+            conductor.set_workflow_state(state)
+            self.assertEqual(conductor._workflow_state, state)
+            self.assertEqual(conductor.get_workflow_state(), state)
+
+        return conductor
+
+    def assert_data_flow(self, input_value):
+        inputs = {'a1': input_value}
+        expected_output = {'a5': inputs['a1'], 'b5': inputs['a1']}
+
+        conductor = self._prep_conductor(inputs, states.RUNNING)
+
+        for i in range(1, len(conductor.spec.tasks) + 1):
+            task_name = 'task' + str(i)
+            conductor.update_task_flow(task_name, states.RUNNING)
+            conductor.update_task_flow(task_name, states.SUCCEEDED)
+
+        self.assertEqual(conductor.get_workflow_state(), states.SUCCEEDED)
+        self.assertDictEqual(conductor.get_workflow_output(), expected_output)
+
+    def test_data_flow_string(self):
+        self.assert_data_flow('xyz')
+
+    def test_data_flow_integer(self):
+        self.assert_data_flow(123)
+        self.assert_data_flow(-123)
+
+    def test_data_flow_float(self):
+        self.assert_data_flow(99.99)
+        self.assert_data_flow(-99.99)
+
+    def test_data_flow_boolean(self):
+        self.assert_data_flow(True)
+        self.assert_data_flow(False)
+
+    def test_data_flow_dict(self):
+        self.assert_data_flow({'x': 123, 'y': 'abc'})
+
+    def test_data_flow_list(self):
+        self.assert_data_flow([123, 'abc', True])
+
+    def test_data_flow_unicode(self):
+        self.assert_data_flow('光合作用')

--- a/orchestra/tests/unit/specs/native/test_workflow_spec.py
+++ b/orchestra/tests/unit/specs/native/test_workflow_spec.py
@@ -59,9 +59,9 @@ class WorkflowSpecTest(base.OrchestraWorkflowSpecTest):
             '<% succeeded() %>'
         )
 
-        self.assertDictEqual(
+        self.assertListEqual(
             getattr(task1_transition_seqs[0], 'publish'),
-            {'greeting': '<% result() %>'}
+            [{'greeting': '<% result() %>'}]
         )
 
         self.assertEqual(
@@ -93,9 +93,9 @@ class WorkflowSpecTest(base.OrchestraWorkflowSpecTest):
             '<% succeeded() %>'
         )
 
-        self.assertDictEqual(
+        self.assertListEqual(
             getattr(task2_transition_seqs[0], 'publish'),
-            {'greeting': '<% $.greeting %>, <% result() %>'}
+            [{'greeting': '<% $.greeting %>, <% result() %>'}]
         )
 
         self.assertListEqual(
@@ -127,9 +127,9 @@ class WorkflowSpecTest(base.OrchestraWorkflowSpecTest):
             '<% succeeded() %>'
         )
 
-        self.assertDictEqual(
+        self.assertListEqual(
             getattr(task3_transition_seqs[0], 'publish'),
-            {'greeting': '<% result() %>'}
+            [{'greeting': '<% result() %>'}]
         )
 
         self.assertEqual(

--- a/orchestra/tests/unit/specs/native/test_workflow_spec_validate.py
+++ b/orchestra/tests/unit/specs/native/test_workflow_spec_validate.py
@@ -92,8 +92,8 @@ class WorkflowSpecValidationTest(base.OrchestraWorkflowSpecTest):
                     message: <% $.foo + $.bar %>
                 next:
                   - publish:
-                        foobar: fubar
-                        fubar: foobar
+                      - foobar: fubar
+                      - fubar: foobar
                     do: task3
               task3:
                 action: core.noop
@@ -244,7 +244,7 @@ class WorkflowSpecValidationTest(base.OrchestraWorkflowSpecTest):
             version: 1.0
             description: A basic sequential workflow.
             vars:
-                macro: polo
+              - macro: polo
             tasks:
               task1:
                 action: core.local cmd=<% $.foobar %>

--- a/orchestra/tests/unit/specs/test_base_spec.py
+++ b/orchestra/tests/unit/specs/test_base_spec.py
@@ -581,7 +581,7 @@ class SpecTest(unittest.TestCase):
                 {
                     'type': 'yaql',
                     'expression': '<% $.fubar %>',
-                    'spec_path': 'attr4',
+                    'spec_path': 'attr4[0]',
                     'schema_path': 'properties.attr4',
                     'message': 'Variable "fubar" is referenced '
                                'before assignment.'
@@ -684,7 +684,7 @@ class SpecTest(unittest.TestCase):
                 {
                     'type': 'yaql',
                     'expression': '<% $.fubar %>',
-                    'spec_path': 'attr4',
+                    'spec_path': 'attr4[0]',
                     'schema_path': 'properties.attr4',
                     'message': 'Variable "fubar" is referenced '
                                'before assignment.'

--- a/orchestra/tests/unit/utils/test_parameters.py
+++ b/orchestra/tests/unit/utils/test_parameters.py
@@ -31,7 +31,7 @@ class InlineParametersTest(unittest.TestCase):
         ]
 
         for s, d in tests:
-            self.assertDictEqual(params.parse_inline_params(s), d)
+            self.assertDictEqual(params.parse_inline_params(s)[0], d)
 
     def test_parse_dictionary(self):
         tests = [
@@ -39,7 +39,7 @@ class InlineParametersTest(unittest.TestCase):
         ]
 
         for s, d in tests:
-            self.assertDictEqual(params.parse_inline_params(s), d)
+            self.assertDictEqual(params.parse_inline_params(s)[0], d)
 
     def test_parse_expression(self):
         tests = [
@@ -48,40 +48,43 @@ class InlineParametersTest(unittest.TestCase):
         ]
 
         for s, d in tests:
-            self.assertDictEqual(params.parse_inline_params(s), d)
+            self.assertDictEqual(params.parse_inline_params(s)[0], d)
 
     def test_parse_multiple(self):
         tests = [
-            ('x="abc" y="def"', {'x': 'abc', 'y': 'def'}),
-            ('x="abc", y="def"', {'x': 'abc', 'y': 'def'}),
-            ('x="abc"; y="def"', {'x': 'abc', 'y': 'def'})
+            ('x="abc" y="def"', [{'x': 'abc'}, {'y': 'def'}]),
+            ('y="def" x="abc"', [{'y': 'def'}, {'x': 'abc'}]),
+            ('x="abc", y="def"', [{'x': 'abc'}, {'y': 'def'}]),
+            ('y="def", x="abc"', [{'y': 'def'}, {'x': 'abc'}]),
+            ('x="abc"; y="def"', [{'x': 'abc'}, {'y': 'def'}]),
+            ('y="def"; x="abc"', [{'y': 'def'}, {'x': 'abc'}])
         ]
 
         for s, d in tests:
-            self.assertDictEqual(params.parse_inline_params(s), d)
+            self.assertListEqual(params.parse_inline_params(s), d)
 
     def test_parse_combination(self):
         s = 'i=123 j="abc" k=true x=<% $.abc %> y={{ _.abc }} z=\'{\"a\": 1}\''
 
-        d = {
-            'i': 123,
-            'j': 'abc',
-            'k': True,
-            'x': '<% $.abc %>',
-            'y': '{{ _.abc }}',
-            'z': {'a': 1}
-        }
+        d = [
+            {'i': 123},
+            {'j': 'abc'},
+            {'k': True},
+            {'x': '<% $.abc %>'},
+            {'y': '{{ _.abc }}'},
+            {'z': {'a': 1}}
+        ]
 
-        self.assertDictEqual(params.parse_inline_params(s), d)
+        self.assertListEqual(params.parse_inline_params(s), d)
 
     def test_parse_empty_string(self):
-        self.assertDictEqual(params.parse_inline_params(str()), {})
+        self.assertListEqual(params.parse_inline_params(str()), [])
 
     def test_parse_null_type(self):
-        self.assertDictEqual(params.parse_inline_params(None), {})
+        self.assertListEqual(params.parse_inline_params(None), [])
 
     def test_parse_other_types(self):
-        self.assertDictEqual(params.parse_inline_params(123), {})
-        self.assertDictEqual(params.parse_inline_params(True), {})
-        self.assertDictEqual(params.parse_inline_params([1, 2, 3]), {})
-        self.assertDictEqual(params.parse_inline_params({'a': 123}), {})
+        self.assertListEqual(params.parse_inline_params(123), [])
+        self.assertListEqual(params.parse_inline_params(True), [])
+        self.assertListEqual(params.parse_inline_params([1, 2, 3]), [])
+        self.assertListEqual(params.parse_inline_params({'a': 123}), [])

--- a/orchestra/utils/parameters.py
+++ b/orchestra/utils/parameters.py
@@ -42,8 +42,9 @@ REGEX_INLINE_PARAM_VARIATIONS.extend([e._regex_pattern for e in expr.get_evaluat
 REGEX_INLINE_PARAMS = '([\w]+)=(%s)' % '|'.join(REGEX_INLINE_PARAM_VARIATIONS)
 
 
-def parse_inline_params(s):
-    params = {}
+def parse_inline_params(s, preserve_order=True):
+    # Use a list to preserve order.
+    params = [] if preserve_order else {}
 
     if s is None or not isinstance(s, six.string_types) or s == str():
         return params
@@ -66,6 +67,9 @@ def parse_inline_params(s):
         except Exception:
             pass
 
-        params[k] = v
+        if preserve_order:
+            params.append({k: v})
+        else:
+            params[k] = v
 
     return params


### PR DESCRIPTION
Refactor schema of workflow input, output, vars, and task publish for the native DSL to list of key-value pairs. The list of key-value pairs will be rendered sequentially. Thus, variables that are declared in the same section and have already been rendered can be referenced by following declaration.