### PR TITLE
Fix staging and state changes in join workflow

### DIFF
--- a/orchestra/tests/unit/conducting/test_workflow_conductor_pause_and_resume.py
+++ b/orchestra/tests/unit/conducting/test_workflow_conductor_pause_and_resume.py
@@ -1,0 +1,78 @@
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orchestra import conducting
+from orchestra.specs import native as specs
+from orchestra import states
+from orchestra.tests.unit import base
+
+
+class WorkflowConductorPauseResumeTest(base.WorkflowConductorTest):
+
+    def test_resume_from_branches(self):
+        wf_def = """
+        version: 1.0
+        description: A basic branching workflow.
+        tasks:
+          # branch 1
+          task1:
+            action: core.noop
+            next:
+              - when: <% succeeded() %>
+                do: task3
+          # branch 2
+          task2:
+            action: core.noop
+            next:
+              - when: <% succeeded() %>
+                do: task3
+          # adjoining branch
+          task3:
+            join: all
+            action: core.noop
+        """
+
+        spec = specs.WorkflowSpec(wf_def)
+        conductor = conducting.WorkflowConductor(spec)
+        conductor.set_workflow_state(states.RUNNING)
+
+        # Run task1 and task2.
+        conductor.update_task_flow('task1', states.RUNNING)
+        conductor.update_task_flow('task2', states.RUNNING)
+        self.assertEqual(conductor.get_workflow_state(), states.RUNNING)
+
+        # Pause task1 and task2.
+        conductor.update_task_flow('task1', states.PAUSED)
+        conductor.update_task_flow('task2', states.PAUSED)
+        self.assertEqual(conductor.get_workflow_state(), states.PAUSED)
+
+        # Resume and complete task1 only. Once task1 completes, the workflow
+        # should pause again because there is no active task.
+        conductor.update_task_flow('task1', states.RUNNING)
+        self.assertEqual(conductor.get_workflow_state(), states.RUNNING)
+        conductor.update_task_flow('task1', states.SUCCEEDED)
+        self.assertEqual(conductor.get_workflow_state(), states.PAUSED)
+
+        # Resume and complete task2. When task2 completes, the workflow
+        # should stay running because task3 is now staged and ready.
+        conductor.update_task_flow('task2', states.RUNNING)
+        self.assertEqual(conductor.get_workflow_state(), states.RUNNING)
+        conductor.update_task_flow('task2', states.SUCCEEDED)
+        self.assertEqual(conductor.get_workflow_state(), states.RUNNING)
+        expected_task = self.format_task_item('task3', {}, conductor.spec.tasks.get_task('task3'))
+        self.assert_task_list(conductor.get_next_tasks('task2'), [expected_task])
+
+        # Complete task3.
+        conductor.update_task_flow('task3', states.RUNNING)
+        self.assertEqual(conductor.get_workflow_state(), states.RUNNING)
+        conductor.update_task_flow('task3', states.SUCCEEDED)
+        self.assertEqual(conductor.get_workflow_state(), states.SUCCEEDED)


### PR DESCRIPTION
To manage context, a staged task is created for the join task even before all inbound criteria is satisfied. This leads to errors in determining workflow state and in getting next tasks. The fix adds a ready flag in the staged tasks and this flag will be set to true when all inbound criteria is satisfied.