### PR TITLE
Remove copy.deepcopy of var extract regexes

### DIFF
--- a/orchestra/expressions/jinja.py
+++ b/orchestra/expressions/jinja.py
@@ -12,7 +12,6 @@
 
 from functools import partial
 
-import copy
 import inspect
 import logging
 import re
@@ -100,7 +99,7 @@ class JinjaEvaluator(base.Evaluator):
 
     @classmethod
     def get_var_extraction_regexes(cls):
-        return copy.deepcopy(cls._regex_var_extracts)
+        return cls._regex_var_extracts
 
     @classmethod
     def validate(cls, text):

--- a/orchestra/expressions/yql.py
+++ b/orchestra/expressions/yql.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import inspect
 import logging
 import re
@@ -83,7 +82,7 @@ class YAQLEvaluator(base.Evaluator):
 
     @classmethod
     def get_var_extraction_regexes(cls):
-        return copy.deepcopy(cls._regex_var_extracts)
+        return cls._regex_var_extracts
 
     @classmethod
     def validate(cls, text):


### PR DESCRIPTION
Remove copy.deepcopy of the var extratc regexes to minimize performance hit.