### PR TITLE
Remove with items from the task spec of native DSL

### DIFF
--- a/orchestra/specs/native/v1/models.py
+++ b/orchestra/specs/native/v1/models.py
@@ -116,7 +116,6 @@ class TaskSpec(base.Spec):
                     types.POSITIVE_INTEGER
                 ]
             },
-            'with': ItemizedSpec,
             'action': types.NONEMPTY_STRING,
             'input': types.NONEMPTY_DICT,
             'next': TaskTransitionSequenceSpec,

--- a/orchestra/tests/unit/specs/native/test_workflow_spec.py
+++ b/orchestra/tests/unit/specs/native/test_workflow_spec.py
@@ -203,21 +203,12 @@ class WorkflowSpecTest(base.OrchestraWorkflowSpecTest):
         wf_name = 'with-items'
         wf_spec = self.get_wf_spec(wf_name)
         t1 = wf_spec.tasks['task1']
-        with_attr = getattr(t1, 'with')
 
-        self.assertIsNotNone(with_attr)
-        self.assertEqual(with_attr.items, 'member in <% ctx().members %>')
-        self.assertEqual(with_attr.concurrency, '<% ctx().batch_size %>')
+        self.assertRaises(AttributeError, getattr, t1, 'with')
 
     def test_with_multi_items(self):
         wf_name = 'with-multi-items'
         wf_spec = self.get_wf_spec(wf_name)
         t1 = wf_spec.tasks['task1']
-        with_attr = getattr(t1, 'with')
 
-        self.assertIsNotNone(with_attr)
-        self.assertIsInstance(with_attr.items, list)
-        self.assertEqual(len(with_attr.items), 2)
-        self.assertIn('member in <% ctx().members %>', with_attr.items)
-        self.assertIn('message in <% ctx().messages %>', with_attr.items)
-        self.assertEqual(with_attr.concurrency, '<% ctx().batch_size %>')
+        self.assertRaises(AttributeError, getattr, t1, 'with')

--- a/orchestra/tests/unit/specs/native/test_workflow_spec_validate.py
+++ b/orchestra/tests/unit/specs/native/test_workflow_spec_validate.py
@@ -355,3 +355,50 @@ class WorkflowSpecValidationTest(base.OrchestraWorkflowSpecTest):
         }
 
         self.assertDictEqual(wf_spec.inspect(), expected_errors)
+
+    def test_with_items(self):
+        wf_def = """
+            version: 1.0
+
+            description: Send direct message to members
+
+            input:
+              - members
+              - message
+              - batch_size: 3
+
+            tasks:
+              task1:
+                with:
+                  items: member in <% ctx().members %>
+                  concurrency: <% ctx().batch_size %>
+                action: slack.post
+                input:
+                  member: <% ctx().member %>
+                  message: <% ctx().message %>
+        """
+
+        wf_spec = self.instantiate(wf_def)
+
+        # With items is not currently supported so we are expecting
+        # errors on the with property and the item variable.
+        expected_errors = {
+            'context': [
+                {
+                    'type': 'yaql',
+                    'expression': '<% ctx().member %>',
+                    'spec_path': 'tasks.task1.input',
+                    'schema_path': 'properties.tasks.patternProperties.^\\w+$.properties.input',
+                    'message': 'Variable "member" is referenced before assignment.'
+                }
+            ],
+            'syntax': [
+                {
+                    'message': "Additional properties are not allowed ('with' was unexpected)",
+                    'spec_path': 'tasks.task1',
+                    'schema_path': 'properties.tasks.patternProperties.^\\w+$.additionalProperties'
+                }
+            ]
+        }
+
+        self.assertDictEqual(wf_spec.inspect(), expected_errors)


### PR DESCRIPTION
For the beta release, the native DSL will not support with items in the task spec. Remove the with items from the schema and ensure error(s) is thrown on inspection.