### PR TITLE
Add flake8 rules to restrict import styles

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 100
-enable-extensions = H203,H204,H205
+enable-extensions = H203,H204,H205,H301
 ignore = E402
 exclude=*.egg/*

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 100
-enable-extensions = H203,H204,H205,H301
+enable-extensions = H203,H204,H205,H301,H303
 ignore = E402
 exclude=*.egg/*

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 100
-enable-extensions = H203,H204,H205,H301,H303
+enable-extensions = H203,H204,H205,H301,H303,H304
 ignore = E402
 exclude=*.egg/*

--- a/.pylintrc
+++ b/.pylintrc
@@ -24,6 +24,6 @@ disable=C0103,C0111,I0011,I0012,W0704,W0142,W0212,W0232,W0613,W0702,R0201,W0614,
 ignored-modules=distutils,eventlet.green.subprocess
 
 [FORMAT]
-max-line-length=80
+max-line-length=100
 max-module-lines=1000
 indent-string='    '

--- a/orquesta/expressions/jinja.py
+++ b/orquesta/expressions/jinja.py
@@ -10,8 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial
-
+import functools
 import inspect
 import logging
 import re
@@ -86,7 +85,7 @@ class JinjaEvaluator(base.Evaluator):
             ctx['__current_task'] = ctx['__vars'].get('__current_task')
 
         for name, func in six.iteritems(cls._custom_functions):
-            ctx[name] = partial(func, ctx)
+            ctx[name] = functools.partial(func, ctx)
 
         return ctx
 

--- a/orquesta/specs/mistral/__init__.py
+++ b/orquesta/specs/mistral/__init__.py
@@ -10,14 +10,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orquesta.specs.mistral import v2
-from orquesta.specs.mistral.v2 import deserialize       # noqa
-from orquesta.specs.mistral.v2 import instantiate       # noqa
-from orquesta.specs.mistral.v2 import TaskDefaultsSpec  # noqa
-from orquesta.specs.mistral.v2 import TaskSpec          # noqa
-from orquesta.specs.mistral.v2 import WorkflowSpec      # noqa
+from orquesta.specs.mistral import v2 as mistral_v2
+from orquesta.specs.mistral.v2 import tasks as mistral_v2_task_models
+from orquesta.specs.mistral.v2 import workflows as mistral_v2_workflow_models
 
-VERSION = v2.VERSION
+
+VERSION = mistral_v2.VERSION
+deserialize = mistral_v2_workflow_models.deserialize
+instantiate = mistral_v2_workflow_models.instantiate
+TaskDefaultsSpec = mistral_v2_task_models.TaskDefaultsSpec
+TaskSpec = mistral_v2_task_models.TaskSpec
+WorkflowSpec = mistral_v2_workflow_models.WorkflowSpec
 
 __all__ = [
     instantiate.__name__,

--- a/orquesta/specs/mistral/v2/__init__.py
+++ b/orquesta/specs/mistral/v2/__init__.py
@@ -10,19 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orquesta.specs.mistral.v2 import base
-from orquesta.specs.mistral.v2.tasks import TaskDefaultsSpec    # noqa
-from orquesta.specs.mistral.v2.tasks import TaskSpec            # noqa
-from orquesta.specs.mistral.v2.workflows import deserialize     # noqa
-from orquesta.specs.mistral.v2.workflows import instantiate     # noqa
-from orquesta.specs.mistral.v2.workflows import WorkflowSpec    # noqa
+from orquesta.specs.mistral.v2 import base as mistral_v2_base
 
-VERSION = base.Spec.get_version()
 
-__all__ = [
-    instantiate.__name__,
-    deserialize.__name__,
-    WorkflowSpec.__name__,
-    TaskDefaultsSpec.__name__,
-    TaskSpec.__name__
-]
+VERSION = mistral_v2_base.Spec.get_version()

--- a/orquesta/specs/mistral/v2/__init__.py
+++ b/orquesta/specs/mistral/v2/__init__.py
@@ -11,11 +11,11 @@
 # limitations under the License.
 
 from orquesta.specs.mistral.v2 import base
-from orquesta.specs.mistral.v2.tasks import TaskDefaultsSpec
-from orquesta.specs.mistral.v2.tasks import TaskSpec
-from orquesta.specs.mistral.v2.workflows import deserialize
-from orquesta.specs.mistral.v2.workflows import instantiate
-from orquesta.specs.mistral.v2.workflows import WorkflowSpec
+from orquesta.specs.mistral.v2.tasks import TaskDefaultsSpec    # noqa
+from orquesta.specs.mistral.v2.tasks import TaskSpec            # noqa
+from orquesta.specs.mistral.v2.workflows import deserialize     # noqa
+from orquesta.specs.mistral.v2.workflows import instantiate     # noqa
+from orquesta.specs.mistral.v2.workflows import WorkflowSpec    # noqa
 
 VERSION = base.Spec.get_version()
 

--- a/orquesta/specs/mock/__init__.py
+++ b/orquesta/specs/mock/__init__.py
@@ -10,12 +10,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orquesta.specs import base
-from orquesta.specs.mock.models import deserialize      # noqa
-from orquesta.specs.mock.models import instantiate      # noqa
-from orquesta.specs.mock.models import WorkflowSpec     # noqa
+from orquesta.specs import base as mock_base
+from orquesta.specs.mock import models as mock_models
 
-VERSION = base.Spec.get_version()
+
+VERSION = mock_base.Spec.get_version()
+deserialize = mock_models.deserialize
+instantiate = mock_models.instantiate
+WorkflowSpec = mock_models.WorkflowSpec
 
 __all__ = [
     instantiate.__name__,

--- a/orquesta/specs/mock/__init__.py
+++ b/orquesta/specs/mock/__init__.py
@@ -11,9 +11,9 @@
 # limitations under the License.
 
 from orquesta.specs import base
-from orquesta.specs.mock.models import deserialize
-from orquesta.specs.mock.models import instantiate
-from orquesta.specs.mock.models import WorkflowSpec
+from orquesta.specs.mock.models import deserialize      # noqa
+from orquesta.specs.mock.models import instantiate      # noqa
+from orquesta.specs.mock.models import WorkflowSpec     # noqa
 
 VERSION = base.Spec.get_version()
 

--- a/orquesta/specs/native/__init__.py
+++ b/orquesta/specs/native/__init__.py
@@ -11,13 +11,13 @@
 # limitations under the License.
 
 from orquesta.specs.native import v1
-from orquesta.specs.native.v1 import deserialize
-from orquesta.specs.native.v1 import instantiate
-from orquesta.specs.native.v1 import TaskMappingSpec
-from orquesta.specs.native.v1 import TaskSpec
-from orquesta.specs.native.v1 import TaskTransitionSequenceSpec
-from orquesta.specs.native.v1 import TaskTransitionSpec
-from orquesta.specs.native.v1 import WorkflowSpec
+from orquesta.specs.native.v1 import deserialize                    # noqa
+from orquesta.specs.native.v1 import instantiate                    # noqa
+from orquesta.specs.native.v1 import TaskMappingSpec                # noqa
+from orquesta.specs.native.v1 import TaskSpec                       # noqa
+from orquesta.specs.native.v1 import TaskTransitionSequenceSpec     # noqa
+from orquesta.specs.native.v1 import TaskTransitionSpec             # noqa
+from orquesta.specs.native.v1 import WorkflowSpec                   # noqa
 
 VERSION = v1.VERSION
 

--- a/orquesta/specs/native/__init__.py
+++ b/orquesta/specs/native/__init__.py
@@ -10,16 +10,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orquesta.specs.native import v1
-from orquesta.specs.native.v1 import deserialize                    # noqa
-from orquesta.specs.native.v1 import instantiate                    # noqa
-from orquesta.specs.native.v1 import TaskMappingSpec                # noqa
-from orquesta.specs.native.v1 import TaskSpec                       # noqa
-from orquesta.specs.native.v1 import TaskTransitionSequenceSpec     # noqa
-from orquesta.specs.native.v1 import TaskTransitionSpec             # noqa
-from orquesta.specs.native.v1 import WorkflowSpec                   # noqa
+from orquesta.specs.native import v1 as native_v1
+from orquesta.specs.native.v1 import models as native_v1_models
 
-VERSION = v1.VERSION
+
+VERSION = native_v1.VERSION
+instantiate = native_v1_models.instantiate
+deserialize = native_v1_models.deserialize
+WorkflowSpec = native_v1_models.WorkflowSpec
+TaskMappingSpec = native_v1_models.TaskMappingSpec
+TaskSpec = native_v1_models.TaskSpec
+TaskTransitionSequenceSpec = native_v1_models.TaskTransitionSequenceSpec
+TaskTransitionSpec = native_v1_models.TaskTransitionSpec
 
 __all__ = [
     instantiate.__name__,

--- a/orquesta/specs/native/v1/__init__.py
+++ b/orquesta/specs/native/v1/__init__.py
@@ -10,23 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orquesta.specs.native.v1 import base
-from orquesta.specs.native.v1.models import deserialize                 # noqa
-from orquesta.specs.native.v1.models import instantiate                 # noqa
-from orquesta.specs.native.v1.models import TaskMappingSpec             # noqa
-from orquesta.specs.native.v1.models import TaskSpec                    # noqa
-from orquesta.specs.native.v1.models import TaskTransitionSequenceSpec  # noqa
-from orquesta.specs.native.v1.models import TaskTransitionSpec          # noqa
-from orquesta.specs.native.v1.models import WorkflowSpec                # noqa
+from orquesta.specs.native.v1 import base as native_v1_base
 
-VERSION = base.Spec.get_version()
 
-__all__ = [
-    instantiate.__name__,
-    deserialize.__name__,
-    WorkflowSpec.__name__,
-    TaskMappingSpec.__name__,
-    TaskSpec.__name__,
-    TaskTransitionSequenceSpec.__name__,
-    TaskTransitionSpec.__name__
-]
+VERSION = native_v1_base.Spec.get_version()

--- a/orquesta/specs/native/v1/__init__.py
+++ b/orquesta/specs/native/v1/__init__.py
@@ -11,13 +11,13 @@
 # limitations under the License.
 
 from orquesta.specs.native.v1 import base
-from orquesta.specs.native.v1.models import deserialize
-from orquesta.specs.native.v1.models import instantiate
-from orquesta.specs.native.v1.models import TaskMappingSpec
-from orquesta.specs.native.v1.models import TaskSpec
-from orquesta.specs.native.v1.models import TaskTransitionSequenceSpec
-from orquesta.specs.native.v1.models import TaskTransitionSpec
-from orquesta.specs.native.v1.models import WorkflowSpec
+from orquesta.specs.native.v1.models import deserialize                 # noqa
+from orquesta.specs.native.v1.models import instantiate                 # noqa
+from orquesta.specs.native.v1.models import TaskMappingSpec             # noqa
+from orquesta.specs.native.v1.models import TaskSpec                    # noqa
+from orquesta.specs.native.v1.models import TaskTransitionSequenceSpec  # noqa
+from orquesta.specs.native.v1.models import TaskTransitionSpec          # noqa
+from orquesta.specs.native.v1.models import WorkflowSpec                # noqa
 
 VERSION = base.Spec.get_version()
 

--- a/orquesta/tests/hacking/__init__.py
+++ b/orquesta/tests/hacking/__init__.py
@@ -10,19 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orquesta.specs.mistral import v2
-from orquesta.specs.mistral.v2 import deserialize       # noqa
-from orquesta.specs.mistral.v2 import instantiate       # noqa
-from orquesta.specs.mistral.v2 import TaskDefaultsSpec  # noqa
-from orquesta.specs.mistral.v2 import TaskSpec          # noqa
-from orquesta.specs.mistral.v2 import WorkflowSpec      # noqa
 
-VERSION = v2.VERSION
+from orquesta.tests.hacking import imports as import_rules
 
-__all__ = [
-    instantiate.__name__,
-    deserialize.__name__,
-    WorkflowSpec.__name__,
-    TaskDefaultsSpec.__name__,
-    TaskSpec.__name__
-]
+
+def factory(register):
+    register(import_rules.check_import_modules_only)

--- a/orquesta/tests/hacking/imports.py
+++ b/orquesta/tests/hacking/imports.py
@@ -1,0 +1,104 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import imp
+import inspect
+import sys
+import traceback
+
+from hacking import core
+
+
+MODULES_CACHE = dict((mod, True) for mod in tuple(sys.modules.keys()) + sys.builtin_module_names)
+
+
+@core.flake8ext
+def check_import_modules_only(logical_line, physical_line, filename, noqa):
+    """Check imports.
+
+    Imports should be modules only.
+
+    Examples:
+    Okay: from orquesta import conducting
+    Okay: from orquesta import states
+    Okay: from orquesta.utils import date
+    O101: from orquesta.conducting import WorkflowConductor
+    O101: from orquesta.states import REQUESTED
+    O101: from orquesta.utils.date import parse
+    """
+
+    if noqa:
+        return
+
+    def check_is_module(mod, search_path=sys.path):
+        mod = mod.replace('(', '')  # Ignore parentheses
+
+        for finder in sys.meta_path:
+            if finder.find_module(mod) is not None:
+                return True
+
+        try:
+            mod_name = mod
+
+            while '.' in mod_name:
+                pack_name, _sep, mod_name = mod_name.partition('.')
+                f, p, d = imp.find_module(pack_name, search_path)
+                search_path = [p]
+
+            imp.find_module(mod_name, search_path)
+        except ImportError:
+            try:
+                # Handle namespace modules
+                if '.' in mod:
+                    pack_name, mod_name = mod.rsplit('.', 1)
+                    __import__(pack_name, fromlist=[mod_name])
+                else:
+                    __import__(mod)
+            except ImportError:
+                # Import error here means the thing is not importable in
+                # current environment, either because of missing dependency,
+                # typo in code being checked, or any other reason. Anyway, we
+                # have no means to know if it is module or not, so we return
+                # True to avoid false positives.
+                return True
+            except Exception:
+                # Skip stack trace on unexpected import error,
+                # log and continue.
+                traceback.print_exc()
+                return False
+            else:
+                # The line was imported. If it is a module, it must be there.
+                # If it is not there under its own name, look to see if it is
+                # a module redirection import..
+                if mod in sys.modules:
+                    return True
+                else:
+                    pack_name, _sep, mod_name = mod.rpartition('.')
+                    if pack_name in sys.modules:
+                        _mod = getattr(sys.modules[pack_name], mod_name, None)
+                        return inspect.ismodule(_mod)
+                    return False
+
+        return True
+
+    def is_module(mod):
+        if mod not in MODULES_CACHE:
+            MODULES_CACHE[mod] = check_is_module(mod)
+
+        return MODULES_CACHE[mod]
+
+    parts = logical_line.split()
+
+    if (len(parts) > 3 and parts[0] == 'from' and parts[1] != '__future__' and
+            not core.is_import_exception(parts[1]) and
+            not is_module('.'.join([parts[1], parts[3]]))):
+        yield 0, 'O101 import must be module only'

--- a/tox.ini
+++ b/tox.ini
@@ -32,3 +32,6 @@ commands =
 setenv = VIRTUALENV_DIR = {envdir}
 commands =
     sphinx-build -W -b html docs/source docs/build/html
+
+[hacking]
+local-check-factory = orquesta.tests.hacking.factory


### PR DESCRIPTION
Add the following flake8 rules to restrict import styles.
- not allow import of more than one module per line
- not allow wildcard (*) imports
- not allow relative imports
- not allow non-module imports