### PR TITLE
Fix state management for task in pending state

### DIFF
--- a/orquesta/states/machines.py
+++ b/orquesta/states/machines.py
@@ -160,12 +160,6 @@ WORKFLOW_STATE_MACHINE_DATA = {
         events.TASK_RUNNING: states.RUNNING,
         events.TASK_PENDING_WORKFLOW_ACTIVE: states.PAUSING,
         events.TASK_PENDING_WORKFLOW_DORMANT: states.PAUSED,
-        # Workflow in resuming state is almost similar to workflow in running state.
-        # Workflow state is not affected by task going into pause states. This allows for more
-        # granular control if operators want to pause a task but keep the rest of running.
-        events.TASK_PAUSING: states.RUNNING,
-        events.TASK_PAUSED_WORKFLOW_ACTIVE: states.RUNNING,
-        events.TASK_PAUSED_WORKFLOW_DORMANT: states.PAUSED,
         events.TASK_SUCCEEDED_WORKFLOW_ACTIVE_INCOMPLETE: states.RUNNING,
         events.TASK_SUCCEEDED_WORKFLOW_ACTIVE_COMPLETED: states.RUNNING,
         events.TASK_SUCCEEDED_WORKFLOW_DORMANT_INCOMPLETE: states.RUNNING,

--- a/orquesta/tests/unit/conducting/test_task_flow.py
+++ b/orquesta/tests/unit/conducting/test_task_flow.py
@@ -123,6 +123,16 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         self.assertEqual(conductor.get_task_flow_idx('task1'), 0)
         self.assertDictEqual(conductor.get_task_flow_entry('task1'), expected_task_flow_item)
 
+    def test_update_task_flow_for_not_ready_task(self):
+        conductor = self._prep_conductor(state=states.RUNNING)
+
+        self.assertRaises(
+            exc.InvalidTaskFlowEntry,
+            conductor.update_task_flow,
+            'task2',
+            events.ActionExecutionEvent(states.RUNNING)
+        )
+
     def test_update_task_flow_for_nonexistent_task(self):
         conductor = self._prep_conductor(state=states.RUNNING)
 

--- a/orquesta/tests/unit/states/native/test_workflow_branching.py
+++ b/orquesta/tests/unit/states/native/test_workflow_branching.py
@@ -123,6 +123,61 @@ class BranchingWorkflowStateTest(base.OrchestraWorkflowConductorTest):
         # Assert the remaining states using the previous conductor.
         self.assert_workflow_state(mock_flow_entries, expected_wf_states, conductor=conductor)
 
+    def test_multiple_pendings(self):
+        mock_flow_entries = [
+            {'id': 'task1', 'name': 'task1', 'state': states.RUNNING},
+            {'id': 'task1', 'name': 'task1', 'state': states.SUCCEEDED},
+            {'id': 'task2', 'name': 'task2', 'state': states.RUNNING},
+            {'id': 'task4', 'name': 'task4', 'state': states.RUNNING},
+            {'id': 'task2', 'name': 'task2', 'state': states.PENDING},
+            {'id': 'task4', 'name': 'task4', 'state': states.PENDING}
+        ]
+
+        expected_wf_states = [
+            states.RUNNING,
+            states.RUNNING,
+            states.RUNNING,
+            states.RUNNING,
+            states.PAUSING,
+            states.PAUSED
+        ]
+
+        # Assert states and then save the conductor for later.
+        conductor = self.assert_workflow_state(mock_flow_entries, expected_wf_states)
+
+        # Resolve the pending tasks.
+        mock_flow_entries = [
+            {'id': 'task2', 'name': 'task2', 'state': states.SUCCEEDED},
+            {'id': 'task4', 'name': 'task4', 'state': states.SUCCEEDED}
+        ]
+
+        expected_wf_states = [
+            states.PAUSED,
+            states.PAUSED
+        ]
+
+        self.assert_workflow_state(mock_flow_entries, expected_wf_states, conductor=conductor)
+
+        # Resume the workflow and assert the remaining states.
+        conductor.request_workflow_state(states.RESUMING)
+
+        mock_flow_entries = [
+            {'id': 'task3', 'name': 'task3', 'state': states.RUNNING},
+            {'id': 'task5', 'name': 'task5', 'state': states.RUNNING},
+            {'id': 'task3', 'name': 'task3', 'state': states.SUCCEEDED},
+            {'id': 'task5', 'name': 'task5', 'state': states.SUCCEEDED}
+        ]
+
+        expected_wf_states = [
+            states.RUNNING,
+            states.RUNNING,
+            states.RUNNING,
+            states.SUCCEEDED
+        ]
+
+        # Assert the remaining states using the previous conductor.
+        self.assert_workflow_state(mock_flow_entries, expected_wf_states, conductor=conductor)
+
     def test_workflow_pausing_then_branch1_and_branch2_succeeded(self):
         # Run workflow until both branches are running.
         mock_flow_entries = [

--- a/orquesta/tests/unit/states/native/test_workflow_sequential.py
+++ b/orquesta/tests/unit/states/native/test_workflow_sequential.py
@@ -90,11 +90,13 @@ class SequentialWorkflowStateTest(base.OrchestraWorkflowConductorTest):
         conductor.request_workflow_state(states.RESUMING)
 
         mock_flow_entries = [
+            {'id': 'task2', 'name': 'task2', 'state': states.SUCCEEDED},
             {'id': 'task3', 'name': 'task3', 'state': states.RUNNING},
             {'id': 'task3', 'name': 'task3', 'state': states.SUCCEEDED}
         ]
 
         expected_wf_states = [
+            states.RUNNING,
             states.RUNNING,
             states.SUCCEEDED
         ]


### PR DESCRIPTION
Task and action execution go into pending state when waiting for human input. This effectively puts the task execution into a paused state. The pending state is added to the conductor function that queries for task in paused state. A bug is also fixed when updating task flow. If the task is not ready and an update is requested, throw an exception. This bug causes inaccurate unit tests that cover pending tasks.