### PR TITLE
Add unit tests to cover repeated calls to get next tasks

### DIFF
--- a/orquesta/tests/unit/conducting/test_workflow_conductor.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor.py
@@ -375,6 +375,29 @@ class WorkflowConductorTest(base.WorkflowConductorTest):
             expected_task = self.format_task_item(next_task_name, expected_ctx_val, next_task_spec)
             self.assert_task_list(conductor.get_next_tasks(task_name), [expected_task])
 
+    def test_get_next_tasks_repeat(self):
+        inputs = {'a': 123}
+        conductor = self._prep_conductor(inputs=inputs, state=states.RUNNING)
+        self.assertEqual(len(conductor.get_next_tasks()), 1)
+
+        conductor.update_task_flow('task1', events.ActionExecutionEvent(states.RUNNING))
+        self.assertEqual(len(conductor.get_next_tasks()), 0)
+
+        conductor.update_task_flow('task1', events.ActionExecutionEvent(states.SUCCEEDED))
+        self.assertEqual(len(conductor.get_next_tasks()), 1)
+
+        conductor.update_task_flow('task2', events.ActionExecutionEvent(states.RUNNING))
+        self.assertEqual(len(conductor.get_next_tasks()), 0)
+
+        self.assertRaises(
+            exc.InvalidTaskStateTransition,
+            conductor.update_task_flow,
+            'task1',
+            events.ActionExecutionEvent(states.SUCCEEDED)
+        )
+
+        self.assertEqual(len(conductor.get_next_tasks()), 0)
+
     def test_get_next_tasks_from_staged(self):
         inputs = {'a': 123}
         conductor = self._prep_conductor(inputs=inputs, state=states.RUNNING)


### PR DESCRIPTION
Add unit tests to cover repeated calls to get next tasks from conductor. Repeated calls should not include tasks that already started running.