### PR TITLE
Inspect context provided by app but not declared explicitly

### DIFF
--- a/orquesta/specs/base.py
+++ b/orquesta/specs/base.py
@@ -244,8 +244,12 @@ class Spec(object):
             if parent else 'properties.' + prop_name
         )
 
-    def inspect(self, raise_exception=False):
+    def inspect(self, app_ctx=None, raise_exception=False):
+        if app_ctx and not isinstance(app_ctx, dict):
+            raise TypeError('Application context is not type of dict.')
+
         errors = {}
+        app_ctx_metadata = None
 
         syntax_errors = sorted(self.inspect_syntax(), key=lambda e: e['schema_path'])
 
@@ -262,7 +266,14 @@ class Spec(object):
         if expr_errors:
             errors['expressions'] = expr_errors
 
-        ctx_errors, _ = self.inspect_context()
+        if app_ctx:
+            app_ctx_metadata = {
+                'ctx': app_ctx.keys(),
+                'spec_path': '.',
+                'schema_path': '.'
+            }
+
+        ctx_errors, _ = self.inspect_context(parent=app_ctx_metadata)
 
         if ctx_errors:
             errors['context'] = ctx_errors

--- a/orquesta/tests/unit/specs/test_base_spec.py
+++ b/orquesta/tests/unit/specs/test_base_spec.py
@@ -712,3 +712,76 @@ class SpecTest(unittest.TestCase):
         self.assertEqual(len(ctx.exception.args), 2)
         self.assertEqual(ctx.exception.args[0], 'Workflow definition failed inspection.')
         self.assertDictEqual(ctx.exception.args[1], errors)
+
+    def test_spec_valid_with_app_ctx(self):
+        spec = {
+            'name': 'mock',
+            'version': '1.0',
+            'description': 'This is a mock spec.',
+            'vars': {
+                'var1': 'foobar',
+                'var2': '<% ctx().x %>',
+                'var3': '<% ctx().y %>'
+            },
+            'attr1': 'foobar',
+            'attr2': {
+                'macro': 'polo'
+            },
+            'attr3': [
+                '<% ctx().var1 %>'
+            ],
+            'attr4': [
+                {'open': 'sesame'},
+                {'sesame': 'open'}
+            ],
+            'attr5': {
+                'attr1': {
+                    'attr1': '<% ctx().var2 %> <% ctx().var3 %>'
+                }
+            }
+        }
+
+        spec_obj = specs.MockSpec(spec)
+        app_ctx = {'x': 'marco', 'y': 'polo'}
+
+        self.assertDictEqual(spec_obj.spec, spec)
+        self.assertDictEqual(spec_obj.inspect(app_ctx=app_ctx), {})
+
+    def test_spec_invalid_with_bad_app_ctx(self):
+        spec = {
+            'name': 'mock',
+            'version': '1.0',
+            'description': 'This is a mock spec.',
+            'vars': {
+                'var1': 'foobar',
+                'var2': '<% ctx().x %>',
+                'var3': '<% ctx().y %>'
+            },
+            'attr1': 'foobar',
+            'attr2': {
+                'macro': 'polo'
+            },
+            'attr3': [
+                '<% ctx().var1 %>'
+            ],
+            'attr4': [
+                {'open': 'sesame'},
+                {'sesame': 'open'}
+            ],
+            'attr5': {
+                'attr1': {
+                    'attr1': '<% ctx().var2 %> <% ctx().var3 %>'
+                }
+            }
+        }
+
+        spec_obj = specs.MockSpec(spec)
+        app_ctx = [{'x': 'marco'}, {'y': 'polo'}]
+
+        self.assertDictEqual(spec_obj.spec, spec)
+
+        self.assertRaises(
+            TypeError,
+            spec_obj.inspect,
+            app_ctx=app_ctx
+        )


### PR DESCRIPTION
Applications for the workflow engine can provide context for workflow execution at runtime. These context are application specific such as execution ID, API URL, etc that may not be friendy to require declaration in every workflow definition. The spec inspection method is refactored to allow optional application context to properly validate references to variables in the context.