### PR TITLE
Check for context argument in function before registration

### DIFF
--- a/orquesta/expressions/base.py
+++ b/orquesta/expressions/base.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import abc
+import inspect
 import logging
 import re
 import six
@@ -151,3 +152,7 @@ def extract_vars(statement):
     variables = [v for v in variables if v[2] != '']
 
     return sorted(list(set(variables)), key=lambda var: var[2])
+
+
+def func_has_ctx_arg(func):
+    return 'context' in inspect.getargspec(func).args

--- a/orquesta/expressions/functions/common.py
+++ b/orquesta/expressions/functions/common.py
@@ -16,7 +16,7 @@ import six
 from orquesta import exceptions as exc
 
 
-def json_(context, s):
+def json_(s):
     if isinstance(s, dict):
         return s
 

--- a/orquesta/expressions/jinja.py
+++ b/orquesta/expressions/jinja.py
@@ -85,7 +85,7 @@ class JinjaEvaluator(base.Evaluator):
             ctx['__current_task'] = ctx['__vars'].get('__current_task')
 
         for name, func in six.iteritems(cls._custom_functions):
-            ctx[name] = functools.partial(func, ctx)
+            ctx[name] = functools.partial(func, ctx) if base.func_has_ctx_arg(func) else func
 
         return ctx
 

--- a/orquesta/tests/unit/expressions/functions/test_common.py
+++ b/orquesta/tests/unit/expressions/functions/test_common.py
@@ -18,15 +18,15 @@ from orquesta.expressions.functions import common as funcs
 class CommonFunctionTest(unittest.TestCase):
 
     def test_convert_json_from_dict(self):
-        self.assertDictEqual(funcs.json_(None, {'k1': 'v1'}), {'k1': 'v1'})
+        self.assertDictEqual(funcs.json_({'k1': 'v1'}), {'k1': 'v1'})
 
     def test_convert_json_from_other_types(self):
-        self.assertRaises(TypeError, funcs.json_, None, 123)
-        self.assertRaises(TypeError, funcs.json_, None, False)
-        self.assertRaises(TypeError, funcs.json_, None, ['a', 'b'])
-        self.assertRaises(TypeError, funcs.json_, None, object())
+        self.assertRaises(TypeError, funcs.json_, 123)
+        self.assertRaises(TypeError, funcs.json_, False)
+        self.assertRaises(TypeError, funcs.json_, ['a', 'b'])
+        self.assertRaises(TypeError, funcs.json_, object())
 
     def test_convert_json(self):
-        self.assertDictEqual(funcs.json_(None, '{"k1": "v1"}'), {'k1': 'v1'})
-        self.assertListEqual(funcs.json_(None, '[{"a": 1}, {"b": 2}]'), [{'a': 1}, {'b': 2}])
-        self.assertListEqual(funcs.json_(None, '[5, 3, 5, 4]'), [5, 3, 5, 4])
+        self.assertDictEqual(funcs.json_('{"k1": "v1"}'), {'k1': 'v1'})
+        self.assertListEqual(funcs.json_('[{"a": 1}, {"b": 2}]'), [{'a': 1}, {'b': 2}])
+        self.assertListEqual(funcs.json_('[5, 3, 5, 4]'), [5, 3, 5, 4])

--- a/orquesta/tests/unit/expressions/test_facade.py
+++ b/orquesta/tests/unit/expressions/test_facade.py
@@ -13,6 +13,7 @@
 import unittest
 
 from orquesta.expressions import base as expressions
+from orquesta.expressions.functions import common as functions
 
 
 class ExpressionEvaluatorTest(unittest.TestCase):
@@ -34,3 +35,7 @@ class ExpressionEvaluatorTest(unittest.TestCase):
             expected_errors,
             result.get('errors', [])
         )
+
+    def test_inspect_function_has_context_argument(self):
+        self.assertTrue(expressions.func_has_ctx_arg(functions.ctx_))
+        self.assertFalse(expressions.func_has_ctx_arg(functions.json_))


### PR DESCRIPTION
Check for context argument in the expression function before registrating it with the Jinja evaluator. This allows general and common functions to not have to unnecessary include a context argument.