### PR TITLE
Fix bugs related to task context

### DIFF
--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -612,13 +612,13 @@ class WorkflowConductor(object):
     def get_task_initial_context(self, task_id):
         task_flow_entry = self.get_task_flow_entry(task_id)
 
-        if task_flow_entry:
-            in_ctx_idx = task_flow_entry.get('ctx')
-            return copy.deepcopy(self.flow.contexts[in_ctx_idx])
-
         if task_id in self.flow.staged:
             in_ctx_idxs = self.flow.staged[task_id]['ctxs']
             return self.converge_task_contexts(in_ctx_idxs)
+
+        if task_flow_entry:
+            in_ctx_idx = task_flow_entry.get('ctx')
+            return copy.deepcopy(self.flow.contexts[in_ctx_idx])
 
         raise ValueError('Unable to determine context for task "%s".' % task_id)
 

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -336,6 +336,8 @@ class WorkflowConductor(object):
         except ValueError:
             task_ctx = self.get_workflow_initial_context()
 
+        current_task = {'id': task_id, 'name': task_name}
+        task_ctx = ctx.set_current_task(task_ctx, current_task)
         task_spec = self.render_task_spec(task_name, task_ctx)
 
         return {

--- a/orquesta/tests/unit/base.py
+++ b/orquesta/tests/unit/base.py
@@ -158,6 +158,7 @@ class WorkflowConductorTest(WorkflowComposerTest):
             task['spec'] = task['spec'].serialize()
 
         for task in expected_copy:
+            task['ctx']['__current_task'] = {'id': task['id'], 'name': task['name']}
             task['spec'] = task['spec'].serialize()
 
         self.assertListEqual(actual_copy, expected_copy)

--- a/orquesta/tests/unit/conducting/test_workflow_conductor.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor.py
@@ -347,18 +347,22 @@ class WorkflowConductorTest(base.WorkflowConductorTest):
         conductor = self._prep_conductor(inputs=inputs, state=states.RUNNING)
 
         task_name = 'task1'
+        current_task = {'id': task_name, 'name': task_name}
+        expected_ctx = {'a': 123, 'b': False, '__current_task': current_task}
         task = conductor.get_task(task_name)
         self.assertEqual(task['id'], task_name)
         self.assertEqual(task['name'], task_name)
-        self.assertDictEqual(task['ctx'], {'a': 123, 'b': False})
+        self.assertDictEqual(task['ctx'], expected_ctx)
         conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.RUNNING))
         conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.SUCCEEDED))
 
         task_name = 'task2'
+        current_task = {'id': task_name, 'name': task_name}
+        expected_ctx = {'a': 123, 'b': False, 'c': 'xyz', '__current_task': current_task}
         task = conductor.get_task(task_name)
         self.assertEqual(task['id'], task_name)
         self.assertEqual(task['name'], task_name)
-        self.assertDictEqual(task['ctx'], {'a': 123, 'b': False, 'c': 'xyz'})
+        self.assertDictEqual(task['ctx'], expected_ctx)
 
     def test_get_next_tasks(self):
         inputs = {'a': 123}

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_cycle.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_cycle.py
@@ -1,0 +1,79 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from orquesta import conducting
+from orquesta import events
+from orquesta.specs import native as specs
+from orquesta import states
+from orquesta.tests.unit import base
+
+
+class WorkflowConductorExtendedTest(base.WorkflowConductorTest):
+
+    def test_self_looping(self):
+        wf_def = """
+        version: 1.0
+
+        description: A basic workflow with cycle.
+
+        vars:
+          - loop: True
+
+        tasks:
+          task1:
+            action: core.noop
+            next:
+              - do: task2
+          task2:
+            action: core.noop
+            next:
+              - when: <% ctx(loop) = true %>
+                publish:
+                  - loop: False
+                do: task2
+        """
+
+        spec = specs.WorkflowSpec(wf_def)
+        conductor = conducting.WorkflowConductor(spec)
+        conductor.request_workflow_state(states.RUNNING)
+
+        # Conduct task1 and check context and that there is no next tasks yet.
+        task_name = 'task1'
+        next_task_name = 'task2'
+        conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.RUNNING))
+        conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.SUCCEEDED))
+        expected_ctx_value = {'loop': True}
+        expected_txsn_ctx = {'task2__0': {'srcs': [], 'value': expected_ctx_value}}
+        self.assertDictEqual(conductor.get_task_transition_contexts(task_name), expected_txsn_ctx)
+        next_task_spec = conductor.spec.tasks.get_task(next_task_name)
+        expected_tasks = [self.format_task_item(next_task_name, expected_ctx_value, next_task_spec)]
+        self.assert_task_list(conductor.get_next_tasks(task_name), expected_tasks)
+
+        # Conduct task2 and check next tasks and context.
+        task_name = 'task2'
+        next_task_name = 'task2'
+        conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.RUNNING))
+        conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.SUCCEEDED))
+        expected_ctx_value = {'loop': False}
+        expected_txsn_ctx = {'task2__0': {'srcs': [1], 'value': expected_ctx_value}}
+        self.assertDictEqual(conductor.get_task_transition_contexts(task_name), expected_txsn_ctx)
+        next_task_spec = conductor.spec.tasks.get_task(next_task_name)
+        expected_tasks = [self.format_task_item(next_task_name, expected_ctx_value, next_task_spec)]
+        self.assert_task_list(conductor.get_next_tasks(task_name), expected_tasks)
+
+        # Conduct task2 and check next tasks and context.
+        task_name = 'task2'
+        next_task_name = 'task2'
+        conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.RUNNING))
+        conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.SUCCEEDED))
+        self.assert_task_list(conductor.get_next_tasks(task_name), [])


### PR DESCRIPTION
Fix current task in context on task spec rendering and determining a task's initial context when a task is self looping. Expressions in task action and input are evaluated when rendering task spec. There are YAQL and Jinja functions that access current task in the context. Set the current task into the context before the task spec is rendered. For a self looping task, an updated context from publish of previous execution is stored in staging. When getting the task initial context, look for the context for the task from staging first otherwise the initial context for subsequent run will be an outdated context.