### PR TITLE
Log error when a failed execution event is received

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,3 +11,4 @@ Changed
 * Replace if else logic with state machines to handle state transition for
   task and workflow execution. (improvement)
 * Clean up conductor and mark some of the methods as private. (improvement)
+* Log an error in the conductor when a failed execution event is received. (improvement)


### PR DESCRIPTION
Add an error entry in the conductor errors log when a failed execution event is received by update_task_flow.