### PR TITLE
Convert strings in context to unicode

### DIFF
--- a/orquesta/tests/unit/conducting/native/test_task_rendering_for_with_items.py
+++ b/orquesta/tests/unit/conducting/native/test_task_rendering_for_with_items.py
@@ -38,7 +38,10 @@ class WorkflowConductorWithItemsTaskRenderingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Item does not have key "y".',
+                'message': (
+                    'Unable to evaluate expression \'<% item(y) %>\'. '
+                    'ExpressionEvaluationException: Item does not have key "y".'
+                ),
                 'task_id': 'task1'
             }
         ]
@@ -73,7 +76,10 @@ class WorkflowConductorWithItemsTaskRenderingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Item is not type of dict.',
+                'message': (
+                    'Unable to evaluate expression \'<% item(x) %>\'. '
+                    'ExpressionEvaluationException: Item is not type of dict.'
+                ),
                 'task_id': 'task1'
             }
         ]

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_error_handling.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_error_handling.py
@@ -55,7 +55,12 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
         """
 
         expected_errors = [
-            {'message': 'Unknown function "#property#value"'}
+            {
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().y.value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                )
+            }
         ]
 
         spec = specs.WorkflowSpec(wf_def)
@@ -104,7 +109,12 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
         """
 
         expected_errors = [
-            {'message': 'Unknown function "#property#value"'}
+            {
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().y.value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                )
+            }
         ]
 
         spec = specs.WorkflowSpec(wf_def)
@@ -150,7 +160,10 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task1',
                 'task_transition_id': 'task2__0'
             }
@@ -210,12 +223,18 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task1',
                 'task_transition_id': 'task3__0'
             },
             {
-                'message': 'Unknown function "#property#foobar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#foobar"'
+                ),
                 'task_id': 'task2',
                 'task_transition_id': 'task3__0'
             }
@@ -272,7 +291,10 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task1',
                 'task_transition_id': 'task2__0'
             }
@@ -325,7 +347,10 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#value"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().y.value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                ),
                 'task_id': 'task1',
                 'task_transition_id': 'task2__0'
             }
@@ -370,7 +395,10 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task1'
             }
         ]
@@ -410,7 +438,10 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task1'
             }
         ]
@@ -450,7 +481,10 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task2'
             }
         ]
@@ -497,7 +531,10 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task1'
             }
         ]
@@ -539,7 +576,10 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task1'
             }
         ]
@@ -581,7 +621,10 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task2'
             }
         ]
@@ -633,11 +676,17 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task1'
             },
             {
-                'message': 'Unknown function "#property#foobar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#foobar"'
+                ),
                 'task_id': 'task2'
             }
         ]
@@ -684,11 +733,17 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task1'
             },
             {
-                'message': 'Unknown function "#property#foobar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#foobar"'
+                ),
                 'task_id': 'task2'
             }
         ]
@@ -731,11 +786,17 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
-                'message': 'Unknown function "#property#fubar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                ),
                 'task_id': 'task2'
             },
             {
-                'message': 'Unknown function "#property#foobar"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#foobar"'
+                ),
                 'task_id': 'task3'
             }
         ]
@@ -800,7 +861,12 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
         """
 
         expected_errors = [
-            {'message': 'Unknown function "#property#value"'}
+            {
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().y.value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                )
+            }
         ]
 
         spec = specs.WorkflowSpec(wf_def)

--- a/orquesta/tests/unit/expressions/test_jinja_eval_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_jinja_eval_by_function_arg.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orquesta import exceptions as exc
 from orquesta.expressions import jinja
 from orquesta.tests.unit import base
 from orquesta.utils import plugin
@@ -45,7 +44,7 @@ class JinjaEvaluationTest(base.ExpressionEvaluatorTest):
         data = {}
 
         self.assertRaises(
-            exc.VariableUndefinedError,
+            jinja.JinjaEvaluationException,
             self.evaluator.evaluate,
             expr,
             data
@@ -104,7 +103,7 @@ class JinjaEvaluationTest(base.ExpressionEvaluatorTest):
         }
 
         self.assertRaises(
-            exc.VariableUndefinedError,
+            jinja.JinjaEvaluationException,
             self.evaluator.evaluate,
             expr,
             data

--- a/orquesta/tests/unit/expressions/test_yaql_eval_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_yaql_eval_by_function_arg.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orquesta import exceptions as exc
 from orquesta.expressions import yql
 from orquesta.tests.unit import base
 from orquesta.utils import plugin
@@ -45,7 +44,7 @@ class YAQLEvaluationTest(base.ExpressionEvaluatorTest):
         data = {}
 
         self.assertRaises(
-            exc.VariableUndefinedError,
+            yql.YaqlEvaluationException,
             self.evaluator.evaluate,
             expr,
             data

--- a/orquesta/tests/unit/utils/test_strings.py
+++ b/orquesta/tests/unit/utils/test_strings.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
 import unittest
 
 from orquesta.utils import strings
@@ -20,3 +23,18 @@ class StringsTest(unittest.TestCase):
     def test_unescape(self):
         self.assertEqual(strings.unescape('foobar'), 'foobar')
         self.assertEqual(strings.unescape('\\\\foobar'), '\\foobar')
+
+    def test_unicode(self):
+        self.assertEqual(strings.unicode(123), 123)
+        self.assertEqual(strings.unicode('foobar'), 'foobar')
+        self.assertEqual(strings.unicode(unicode('foobar') if six.PY2 else str('foobar')), 'foobar')
+        self.assertEqual(strings.unicode('鐵甲奇俠'), '鐵甲奇俠')
+        self.assertEqual(strings.unicode('\xe9\x90\xb5\xe7\x94\xb2'), '\xe9\x90\xb5\xe7\x94\xb2')
+
+    def test_unicode_force(self):
+        self.assertEqual(strings.unicode(123, force=True), '123')
+        self.assertEqual(strings.unicode(123.45, force=True), '123.45')
+        self.assertEqual(strings.unicode(True, force=True), 'True')
+        self.assertEqual(strings.unicode(None, force=True), 'None')
+        self.assertEqual(strings.unicode([1, 2, 3], force=True), '[1, 2, 3]')
+        self.assertEqual(strings.unicode({'k': 'v'}, force=True), "{'k': 'v'}")

--- a/orquesta/utils/strings.py
+++ b/orquesta/utils/strings.py
@@ -12,7 +12,11 @@
 
 import logging
 
+import chardet
 import six
+
+if six.PY2:
+    import __builtin__
 
 
 LOG = logging.getLogger(__name__)
@@ -20,3 +24,20 @@ LOG = logging.getLogger(__name__)
 
 def unescape(s):
     return s.decode('string_escape') if six.PY2 else bytes(s, 'utf-8').decode('unicode_escape')
+
+
+def encoding(s):
+    return chardet.detect(s)['encoding']
+
+
+def unicode(s, force=False):
+    if not isinstance(s, six.string_types) and not force:
+        return s
+
+    if six.PY2:
+        if not force and (isinstance(s, __builtin__.unicode) or encoding(s) == 'utf-8'):
+            return s
+
+        return __builtin__.unicode(s)
+
+    return str(s)


### PR DESCRIPTION
Make strings in context unicode by default. This will avoid problems with manipulating strings of mix ascii and unicode type in expressions.