### PR TITLE
Refactor task transition to include spec reference in the graph edge

### DIFF
--- a/orquesta/composers/mistral.py
+++ b/orquesta/composers/mistral.py
@@ -100,8 +100,20 @@ class WorkflowComposer(base.WorkflowComposer):
                 crta = cls._compose_transition_criteria(task_name, condition=condition, expr=expr)
                 seqs = wf_graph.has_transition(task_name, next_task_name, criteria=crta)
 
-                if not seqs:
-                    wf_graph.add_transition(task_name, next_task_name, criteria=crta)
+                # Use existing transition if present otherwise create new transition.
+                if seqs:
+                    wf_graph.update_transition(
+                        task_name,
+                        next_task_name,
+                        key=seqs[0][2],
+                        criteria=crta
+                    )
+                else:
+                    wf_graph.add_transition(
+                        task_name,
+                        next_task_name,
+                        criteria=crta
+                    )
 
         return wf_graph
 
@@ -191,6 +203,25 @@ class WorkflowComposer(base.WorkflowComposer):
                     for c in prev_seq[3]['criteria']
                 ]
 
-                wf_ex_graph.add_transition(p_task_ex_name, task_ex_name, criteria=p_seq_criteria)
+                seqs = wf_ex_graph.has_transition(
+                    p_task_ex_name,
+                    task_ex_name,
+                    criteria=p_seq_criteria
+                )
+
+                # Use existing transition if present otherwise create new transition.
+                if seqs:
+                    wf_ex_graph.update_transition(
+                        p_task_ex_name,
+                        task_ex_name,
+                        key=seqs[0][2],
+                        criteria=p_seq_criteria
+                    )
+                else:
+                    wf_ex_graph.add_transition(
+                        p_task_ex_name,
+                        task_ex_name,
+                        criteria=p_seq_criteria
+                    )
 
         return wf_ex_graph

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -639,7 +639,7 @@ class WorkflowConductor(object):
 
                     out_ctx_val, errors = task_spec.finalize_context(
                         next_task_name,
-                        criteria,
+                        task_transition,
                         copy.deepcopy(current_ctx)
                     )
 

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -240,9 +240,13 @@ class WorkflowConductor(object):
         log = self.errors if entry_type == 'error' else self.log
         log.append(entry)
 
+    def log_error(self, e, task_id=None, task_transition_id=None):
+        message = '%s: %s' % (type(e).__name__, str(e))
+        self.log_entry('error', message, task_id=task_id, task_transition_id=task_transition_id)
+
     def log_errors(self, errors, task_id=None, task_transition_id=None):
         for error in errors:
-            self.log_entry('error', error, task_id=task_id, task_transition_id=task_transition_id)
+            self.log_error(error, task_id=task_id, task_transition_id=task_transition_id)
 
     def get_workflow_parent_context(self):
         return copy.deepcopy(self._parent_ctx)
@@ -454,7 +458,7 @@ class WorkflowConductor(object):
                     if 'actions' in next_task and len(next_task['actions']) > 0:
                         next_tasks.append(next_task)
                 except Exception as e:
-                    self.log_entry('error', str(e), task_id=staged_task_id)
+                    self.log_error(e, task_id=staged_task_id)
                     self.request_workflow_state(states.FAILED)
                     continue
         else:
@@ -490,7 +494,7 @@ class WorkflowConductor(object):
                     if 'actions' in next_task and len(next_task['actions']) > 0:
                         next_tasks.append(next_task)
                 except Exception as e:
-                    self.log_entry('error', str(e), task_id=next_task_id)
+                    self.log_error(e, task_id=next_task_id)
                     self.request_workflow_state(states.FAILED)
                     continue
 
@@ -623,7 +627,7 @@ class WorkflowConductor(object):
                     evaluated_criteria = [expr.evaluate(c, current_ctx) for c in criteria]
                     task_flow_entry[task_transition_id] = all(evaluated_criteria)
                 except Exception as e:
-                    self.log_entry('error', str(e), task_id, task_transition_id)
+                    self.log_error(e, task_id, task_transition_id)
                     self.request_workflow_state(states.FAILED)
                     continue
 

--- a/orquesta/exceptions.py
+++ b/orquesta/exceptions.py
@@ -113,3 +113,7 @@ class WorkflowInspectionError(Exception):
 
 class WorkflowContextError(Exception):
     pass
+
+
+class WorkflowLogEntryError(Exception):
+    pass

--- a/orquesta/specs/mistral/v2/tasks.py
+++ b/orquesta/specs/mistral/v2/tasks.py
@@ -147,7 +147,8 @@ class TaskSpec(base.Spec):
 
         return self, action_specs
 
-    def finalize_context(self, next_task_name, criteria, in_ctx):
+    def finalize_context(self, next_task_name, task_transition_meta, in_ctx):
+        criteria = task_transition_meta[3].get('criteria') or []
         expected_criteria_pattern = "<\% task_state\(\w+\) in \['succeeded'\] \%>"
         new_ctx = {}
         errors = []

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -240,7 +240,7 @@ class TaskSpec(base.Spec):
                         rolling_ctx[var_name] = rendered_var_value
                         new_ctx[var_name] = rendered_var_value
                     except exc.ExpressionEvaluationException as e:
-                        errors.append(str(e))
+                        errors.append(e)
 
                 break
 
@@ -561,7 +561,7 @@ class WorkflowSpec(base.Spec):
                 rendered_input_value = expr.evaluate(runtime_input_value, rolling_ctx)
                 rolling_ctx[input_name] = rendered_input_value
             except exc.ExpressionEvaluationException as e:
-                errors.append(str(e))
+                errors.append(e)
 
         return rolling_ctx, errors
 
@@ -579,7 +579,7 @@ class WorkflowSpec(base.Spec):
                 rolling_ctx[var_name] = rendered_var_value
                 rendered_vars[var_name] = rendered_var_value
             except exc.ExpressionEvaluationException as e:
-                errors.append(str(e))
+                errors.append(e)
 
         return rendered_vars, errors
 
@@ -598,6 +598,6 @@ class WorkflowSpec(base.Spec):
                 rolling_ctx[output_name] = rendered_output_value
                 rendered_outputs[output_name] = rendered_output_value
             except exc.ExpressionEvaluationException as e:
-                errors.append(str(e))
+                errors.append(e)
 
         return rendered_outputs, errors

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -281,7 +281,7 @@ class TaskMappingSpec(base.MappingSpec):
 
         task_transitions = getattr(task_spec, 'next') or []
 
-        for task_transition in task_transitions:
+        for task_transition_item_idx, task_transition in enumerate(task_transitions):
             condition = getattr(task_transition, 'when') or None
             next_task_names = getattr(task_transition, 'do') or []
 
@@ -289,7 +289,7 @@ class TaskMappingSpec(base.MappingSpec):
                 next_task_names = [x.strip() for x in next_task_names.split(',')]
 
             for next_task_name in next_task_names:
-                next_tasks.append((next_task_name, condition))
+                next_tasks.append((next_task_name, condition, task_transition_item_idx))
 
         return sorted(next_tasks, key=lambda x: x[0])
 
@@ -299,13 +299,13 @@ class TaskMappingSpec(base.MappingSpec):
         for name, task_spec in six.iteritems(self):
             for next_task in self.get_next_tasks(name):
                 if task_name == next_task[0]:
-                    prev_tasks.append((name, next_task[1]))
+                    prev_tasks.append((name, next_task[1], next_task[2]))
 
         return sorted(prev_tasks, key=lambda x: x[0])
 
     def get_start_tasks(self):
         start_tasks = [
-            (task_name, None)
+            (task_name, None, None)
             for task_name in self.keys()
             if not self.get_prev_tasks(task_name)
         ]

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -213,36 +213,26 @@ class TaskSpec(base.Spec):
 
         return self, action_specs
 
-    def finalize_context(self, next_task_name, criteria, in_ctx):
+    def finalize_context(self, next_task_name, task_transition_meta, in_ctx):
         rolling_ctx = copy.deepcopy(in_ctx)
         new_ctx = {}
         errors = []
 
         task_transition_specs = getattr(self, 'next') or []
+        task_transition_spec = task_transition_specs[task_transition_meta[3]['ref']]
+        next_task_names = getattr(task_transition_spec, 'do') or []
 
-        for task_transition_spec in task_transition_specs:
-            condition = getattr(task_transition_spec, 'when') or None
-            next_task_names = getattr(task_transition_spec, 'do') or []
+        if next_task_name in next_task_names:
+            for task_publish_spec in (getattr(task_transition_spec, 'publish') or {}):
+                var_name = list(task_publish_spec.items())[0][0]
+                default_var_value = list(task_publish_spec.items())[0][1]
 
-            if next_task_name in next_task_names:
-                if (condition and len(criteria) <= 0) or (not condition and len(criteria) > 0):
-                    continue
-
-                if condition and len(criteria) > 0 and condition != criteria[0]:
-                    continue
-
-                for task_publish_spec in (getattr(task_transition_spec, 'publish') or {}):
-                    var_name = list(task_publish_spec.items())[0][0]
-                    default_var_value = list(task_publish_spec.items())[0][1]
-
-                    try:
-                        rendered_var_value = expr.evaluate(default_var_value, rolling_ctx)
-                        rolling_ctx[var_name] = rendered_var_value
-                        new_ctx[var_name] = rendered_var_value
-                    except exc.ExpressionEvaluationException as e:
-                        errors.append(e)
-
-                break
+                try:
+                    rendered_var_value = expr.evaluate(default_var_value, rolling_ctx)
+                    rolling_ctx[var_name] = rendered_var_value
+                    new_ctx[var_name] = rendered_var_value
+                except exc.ExpressionEvaluationException as e:
+                    errors.append(e)
 
         out_ctx = dx.merge_dicts(in_ctx, new_ctx, overwrite=True)
 

--- a/orquesta/tests/fixtures/workflows/native/task-duplicate-transition.yaml
+++ b/orquesta/tests/fixtures/workflows/native/task-duplicate-transition.yaml
@@ -1,0 +1,14 @@
+version: 1.0
+  
+description: A basic workflow with task transitions having duplicate condition.
+
+tasks:
+  task1:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task2
+      - when: <% succeeded() %>
+        do: task2
+  task2:
+    action: core.noop

--- a/orquesta/tests/fixtures/workflows/native/task-duplicate-when.yaml
+++ b/orquesta/tests/fixtures/workflows/native/task-duplicate-when.yaml
@@ -1,0 +1,16 @@
+version: 1.0
+  
+description: A basic workflow with task transitions having duplicate condition.
+
+tasks:
+  task1:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task2
+      - when: <% succeeded() %>
+        do: task3
+  task2:
+    action: core.noop
+  task3:
+    action: core.noop

--- a/orquesta/tests/unit/composition/native/test_workflow_basic.py
+++ b/orquesta/tests/unit/composition/native/test_workflow_basic.py
@@ -40,6 +40,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -47,6 +48,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -54,6 +56,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'noop',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -90,6 +93,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -97,6 +101,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -104,6 +109,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'noop',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -145,6 +151,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -152,6 +159,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -160,6 +168,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -167,6 +176,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -211,6 +221,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -218,6 +229,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -226,6 +238,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -233,6 +246,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -271,11 +285,13 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -283,6 +299,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -291,6 +308,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -331,11 +349,13 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -343,6 +363,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -351,6 +372,7 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -386,16 +408,19 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'a',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() and ctx().which = "a" %>']
                     },
                     {
                         'id': 'b',
                         'key': 0,
+                        'ref': 1,
                         'criteria': ['<% succeeded() and ctx().which = "b" %>']
                     },
                     {
                         'id': 'c',
                         'key': 0,
+                        'ref': 2,
                         'criteria': ['<% succeeded() and not ctx().which in list(a, b) %>']
                     }
                 ],
@@ -434,16 +459,19 @@ class BasicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'a',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() and ctx().which = "a" %>']
                     },
                     {
                         'id': 'b',
                         'key': 0,
+                        'ref': 1,
                         'criteria': ['<% succeeded() and ctx().which = "b" %>']
                     },
                     {
                         'id': 'c',
                         'key': 0,
+                        'ref': 2,
                         'criteria': ['<% succeeded() and not ctx().which in list(a, b) %>']
                     }
                 ],

--- a/orquesta/tests/unit/composition/native/test_workflow_cycle.py
+++ b/orquesta/tests/unit/composition/native/test_workflow_cycle.py
@@ -40,6 +40,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -47,6 +48,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -54,6 +56,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -61,6 +64,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() and ctx().count < 2 %>']
                     }
                 ]
@@ -96,6 +100,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -103,6 +108,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -110,6 +116,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -117,6 +124,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() and ctx().count < 2 %>']
                     }
                 ]
@@ -157,6 +165,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -164,6 +173,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -171,11 +181,13 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() and not ctx().proceed %>']
                     },
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 1,
                         'criteria': ['<% succeeded() and ctx().proceed %>']
                     }
                 ],
@@ -183,6 +195,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -190,6 +203,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -197,6 +211,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() and ctx().count < 2 %>']
                     }
                 ]
@@ -240,6 +255,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -247,6 +263,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -254,11 +271,13 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() and not ctx().proceed %>']
                     },
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 1,
                         'criteria': ['<% succeeded() and ctx().proceed %>']
                     }
                 ],
@@ -266,6 +285,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -273,6 +293,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -280,6 +301,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() and ctx().count < 2 %>']
                     }
                 ]
@@ -322,6 +344,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'create',
                         'key': 0,
+                        'ref': 0,
                         'criteria': [
                             '<% succeeded() %>'
                         ]
@@ -329,6 +352,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'check',
                         'key': 0,
+                        'ref': 0,
                         'criteria': [
                             '<% succeeded() %>'
                         ]
@@ -339,6 +363,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'check',
                         'key': 0,
+                        'ref': 0,
                         'criteria': [
                             '<% succeeded() %>'
                         ]
@@ -348,6 +373,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'rollback',
                         'key': 0,
+                        'ref': 1,
                         'criteria': [
                             '<% failed() %>'
                         ]
@@ -355,6 +381,7 @@ class CyclicWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'delete',
                         'key': 0,
+                        'ref': 0,
                         'criteria': [
                             '<% succeeded() %>'
                         ]

--- a/orquesta/tests/unit/composition/native/test_workflow_join.py
+++ b/orquesta/tests/unit/composition/native/test_workflow_join.py
@@ -50,11 +50,13 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -62,6 +64,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -69,6 +72,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -76,6 +80,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -83,6 +88,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -90,6 +96,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -139,11 +146,13 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -151,6 +160,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -158,6 +168,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -165,6 +176,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -172,6 +184,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -179,6 +192,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -227,16 +241,19 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -244,6 +261,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -251,6 +269,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -258,6 +277,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -265,6 +285,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -272,6 +293,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -279,6 +301,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -332,16 +355,19 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -349,6 +375,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -356,6 +383,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -363,6 +391,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -370,6 +399,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -377,6 +407,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -384,6 +415,7 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],

--- a/orquesta/tests/unit/composition/native/test_workflow_split.py
+++ b/orquesta/tests/unit/composition/native/test_workflow_split.py
@@ -54,11 +54,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -66,6 +68,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -73,6 +76,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -80,11 +84,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -92,6 +98,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -99,6 +106,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -173,11 +181,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -185,6 +195,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -192,11 +203,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                 ],
@@ -204,6 +217,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -212,6 +226,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -219,6 +234,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -226,11 +242,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                 ],
@@ -238,6 +256,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -246,6 +265,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ]
@@ -298,16 +318,19 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -315,6 +338,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -322,6 +346,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -329,11 +354,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -341,6 +368,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -348,6 +376,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -355,6 +384,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -444,16 +474,19 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task8__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -461,6 +494,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -468,11 +502,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                 ],
@@ -480,6 +516,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -487,6 +524,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -495,6 +533,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -502,6 +541,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -509,11 +549,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                 ],
@@ -521,6 +563,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -528,6 +571,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8__3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -536,6 +580,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -597,11 +642,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -609,6 +656,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -616,6 +664,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -623,11 +672,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -635,6 +686,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -642,6 +694,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -649,11 +702,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task9',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -661,6 +716,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task10',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -668,6 +724,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task10',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -814,11 +871,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -826,6 +885,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -833,11 +893,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                 ],
@@ -845,6 +907,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -852,11 +915,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task9__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -864,6 +929,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task10__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -872,6 +938,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task10__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -879,6 +946,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -886,11 +954,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task9__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -898,6 +968,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task10__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -906,6 +977,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task10__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -913,6 +985,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -920,11 +993,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                 ],
@@ -932,6 +1007,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -939,11 +1015,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8__3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task9__3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -951,6 +1029,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task10__3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -959,6 +1038,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task10__3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -966,6 +1046,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -973,11 +1054,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8__4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task9__4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -985,6 +1068,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task10__4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -993,6 +1077,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task10__4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ]
@@ -1046,16 +1131,19 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1063,6 +1151,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1070,6 +1159,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1077,11 +1167,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1089,6 +1181,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1096,6 +1189,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1103,6 +1197,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1189,21 +1284,25 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task8__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task8__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1211,6 +1310,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1218,11 +1318,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                 ],
@@ -1230,6 +1332,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1237,6 +1340,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1245,6 +1349,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1252,6 +1357,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task4__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1259,11 +1365,13 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task5__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task6__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                 ],
@@ -1271,6 +1379,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1278,6 +1387,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task8__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -1286,6 +1396,7 @@ class SplitWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task7__2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     }
                 ]

--- a/orquesta/tests/unit/composition/native/test_workflow_task_transition.py
+++ b/orquesta/tests/unit/composition/native/test_workflow_task_transition.py
@@ -37,11 +37,13 @@ class TaskTransitionWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 1,
                         'criteria': ['<% failed() %>']
                     }
                 ],
@@ -75,12 +77,173 @@ class TaskTransitionWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 1,
                         'criteria': ['<% failed() %>']
+                    }
+                ],
+                [],
+                []
+            ],
+            'multigraph': True
+        }
+
+        self.assert_compose_to_wf_ex_graph(wf_name, expected_wf_ex_graph)
+
+    def test_task_with_duplicate_when(self):
+        wf_name = 'task-duplicate-when'
+
+        expected_wf_graph = {
+            'directed': True,
+            'graph': {},
+            'nodes': [
+                {
+                    'id': 'task1'
+                },
+                {
+                    'id': 'task2'
+                },
+                {
+                    'id': 'task3'
+                }
+            ],
+            'adjacency': [
+                [
+                    {
+                        'id': 'task2',
+                        'key': 0,
+                        'ref': 0,
+                        'criteria': ['<% succeeded() %>']
+                    },
+                    {
+                        'id': 'task3',
+                        'key': 0,
+                        'ref': 1,
+                        'criteria': ['<% succeeded() %>']
+                    }
+                ],
+                [],
+                []
+            ],
+            'multigraph': True
+        }
+
+        self.assert_compose_to_wf_graph(wf_name, expected_wf_graph)
+
+        expected_wf_ex_graph = {
+            'directed': True,
+            'graph': {},
+            'nodes': [
+                {
+                    'id': 'task1',
+                    'name': 'task1'
+                },
+                {
+                    'id': 'task2',
+                    'name': 'task2'
+                },
+                {
+                    'id': 'task3',
+                    'name': 'task3'
+                }
+            ],
+            'adjacency': [
+                [
+                    {
+                        'id': 'task2',
+                        'key': 0,
+                        'ref': 0,
+                        'criteria': ['<% succeeded() %>']
+                    },
+                    {
+                        'id': 'task3',
+                        'key': 0,
+                        'ref': 1,
+                        'criteria': ['<% succeeded() %>']
+                    }
+                ],
+                [],
+                []
+            ],
+            'multigraph': True
+        }
+
+        self.assert_compose_to_wf_ex_graph(wf_name, expected_wf_ex_graph)
+
+    def test_task_with_duplicate_transition(self):
+        wf_name = 'task-duplicate-transition'
+
+        expected_wf_graph = {
+            'directed': True,
+            'graph': {},
+            'nodes': [
+                {
+                    'id': 'task1'
+                },
+                {
+                    'id': 'task2',
+                    'splits': ['task2']
+                }
+            ],
+            'adjacency': [
+                [
+                    {
+                        'id': 'task2',
+                        'key': 0,
+                        'ref': 0,
+                        'criteria': ['<% succeeded() %>']
+                    },
+                    {
+                        'id': 'task2',
+                        'key': 1,
+                        'ref': 1,
+                        'criteria': ['<% succeeded() %>']
+                    }
+                ],
+                []
+            ],
+            'multigraph': True
+        }
+
+        self.assert_compose_to_wf_graph(wf_name, expected_wf_graph)
+
+        expected_wf_ex_graph = {
+            'directed': True,
+            'graph': {},
+            'nodes': [
+                {
+                    'id': 'task1',
+                    'name': 'task1'
+                },
+                {
+                    'id': 'task2__1',
+                    'name': 'task2',
+                    'splits': [('task2', 1)]
+                },
+                {
+                    'id': 'task2__2',
+                    'name': 'task2',
+                    'splits': [('task2', 2)]
+                }
+            ],
+            'adjacency': [
+                [
+                    {
+                        'id': 'task2__1',
+                        'key': 0,
+                        'ref': 0,
+                        'criteria': ['<% succeeded() %>']
+                    },
+                    {
+                        'id': 'task2__2',
+                        'key': 0,
+                        'ref': 1,
+                        'criteria': ['<% succeeded() %>']
                     }
                 ],
                 [],
@@ -116,16 +279,19 @@ class TaskTransitionWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 1,
                         'criteria': ['<% failed() %>']
                     },
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 2,
                         'criteria': []
                     }
                 ],
@@ -164,16 +330,19 @@ class TaskTransitionWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': ['<% succeeded() %>']
                     },
                     {
                         'id': 'task3',
                         'key': 0,
+                        'ref': 1,
                         'criteria': ['<% failed() %>']
                     },
                     {
                         'id': 'task4',
                         'key': 0,
+                        'ref': 2,
                         'criteria': []
                     }
                 ],
@@ -206,16 +375,19 @@ class TaskTransitionWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2',
                         'key': 0,
+                        'ref': 0,
                         'criteria': []
                     },
                     {
                         'id': 'task2',
                         'key': 1,
+                        'ref': 1,
                         'criteria': ['<% failed() %>']
                     },
                     {
                         'id': 'task2',
                         'key': 2,
+                        'ref': 2,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],
@@ -255,16 +427,19 @@ class TaskTransitionWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     {
                         'id': 'task2__1',
                         'key': 0,
+                        'ref': 0,
                         'criteria': []
                     },
                     {
                         'id': 'task2__2',
                         'key': 0,
+                        'ref': 1,
                         'criteria': ['<% failed() %>']
                     },
                     {
                         'id': 'task2__3',
                         'key': 0,
+                        'ref': 2,
                         'criteria': ['<% succeeded() %>']
                     }
                 ],

--- a/orquesta/tests/unit/conducting/native/test_task_rendering_for_with_items.py
+++ b/orquesta/tests/unit/conducting/native/test_task_rendering_for_with_items.py
@@ -40,7 +40,7 @@ class WorkflowConductorWithItemsTaskRenderingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% item(y) %>\'. '
+                    'YaqlEvaluationException: Unable to evaluate expression \'<% item(y) %>\'. '
                     'ExpressionEvaluationException: Item does not have key "y".'
                 ),
                 'task_id': 'task1'
@@ -79,7 +79,7 @@ class WorkflowConductorWithItemsTaskRenderingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% item(x) %>\'. '
+                    'YaqlEvaluationException: Unable to evaluate expression \'<% item(x) %>\'. '
                     'ExpressionEvaluationException: Item is not type of dict.'
                 ),
                 'task_id': 'task1'
@@ -113,7 +113,7 @@ class WorkflowConductorWithItemsTaskRenderingTest(base.WorkflowConductorTest):
         expected_errors = [
             {
                 'type': 'error',
-                'message': 'The value of "<% ctx(xs) %>" is not type of list.',
+                'message': 'TypeError: The value of "<% ctx(xs) %>" is not type of list.',
                 'task_id': 'task1'
             }
         ]

--- a/orquesta/tests/unit/conducting/native/test_task_rendering_for_with_items.py
+++ b/orquesta/tests/unit/conducting/native/test_task_rendering_for_with_items.py
@@ -38,6 +38,7 @@ class WorkflowConductorWithItemsTaskRenderingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% item(y) %>\'. '
                     'ExpressionEvaluationException: Item does not have key "y".'
@@ -76,6 +77,7 @@ class WorkflowConductorWithItemsTaskRenderingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% item(x) %>\'. '
                     'ExpressionEvaluationException: Item is not type of dict.'
@@ -110,6 +112,7 @@ class WorkflowConductorWithItemsTaskRenderingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': 'The value of "<% ctx(xs) %>" is not type of list.',
                 'task_id': 'task1'
             }

--- a/orquesta/tests/unit/conducting/test_task_flow.py
+++ b/orquesta/tests/unit/conducting/test_task_flow.py
@@ -149,6 +149,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': 'Execution failed. See result for details.',
                 'task_id': 'task1',
                 'result': {'stdout': 'boom!'}

--- a/orquesta/tests/unit/conducting/test_workflow_conductor.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor.py
@@ -756,6 +756,8 @@ class WorkflowConductorTest(base.WorkflowConductorTest):
         conductor.log_entry('info', 'The workflow is running as expected.', data=extra)
         conductor.log_entry('warn', 'The task may be running a little bit slow.', task_id='task1')
         conductor.log_entry('error', 'This is baloney.', task_id='task1')
+        conductor.log_error(TypeError('Something is not right.'), task_id='task1')
+        conductor.log_errors([KeyError('task1'), ValueError('foobar')], task_id='task1')
 
         self.assertRaises(
             exc.WorkflowLogEntryError,
@@ -781,6 +783,21 @@ class WorkflowConductorTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': 'This is baloney.',
+                'task_id': 'task1'
+            },
+            {
+                'type': 'error',
+                'message': 'TypeError: Something is not right.',
+                'task_id': 'task1'
+            },
+            {
+                'type': 'error',
+                'message': "KeyError: 'task1'",
+                'task_id': 'task1'
+            },
+            {
+                'type': 'error',
+                'message': 'ValueError: foobar',
                 'task_id': 'task1'
             }
         ]

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_error_handling.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_error_handling.py
@@ -58,8 +58,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().y.value %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().y.value %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#value"'
                 )
             }
         ]
@@ -113,8 +114,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().y.value %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().y.value %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#value"'
                 )
             }
         ]
@@ -164,8 +166,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task1',
                 'task_transition_id': 'task2__0'
@@ -228,8 +231,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task1',
                 'task_transition_id': 'task3__0'
@@ -237,8 +241,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#foobar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().fubar.foobar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#foobar"'
                 ),
                 'task_id': 'task2',
                 'task_transition_id': 'task3__0'
@@ -298,8 +303,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task1',
                 'task_transition_id': 'task2__0'
@@ -355,8 +361,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().y.value %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().y.value %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#value"'
                 ),
                 'task_id': 'task1',
                 'task_transition_id': 'task2__0'
@@ -404,8 +411,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task1'
             }
@@ -448,8 +456,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task1'
             }
@@ -492,8 +501,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task2'
             }
@@ -543,8 +553,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task1'
             }
@@ -589,8 +600,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task1'
             }
@@ -635,8 +647,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task2'
             }
@@ -691,16 +704,18 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task1'
             },
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#foobar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().fubar.foobar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#foobar"'
                 ),
                 'task_id': 'task2'
             }
@@ -750,16 +765,18 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task1'
             },
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#foobar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().fubar.foobar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#foobar"'
                 ),
                 'task_id': 'task2'
             }
@@ -805,16 +822,18 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#fubar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().foobar.fubar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#fubar"'
                 ),
                 'task_id': 'task2'
             },
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#foobar"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().fubar.foobar %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#foobar"'
                 ),
                 'task_id': 'task3'
             }
@@ -883,8 +902,9 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             {
                 'type': 'error',
                 'message': (
-                    'Unable to evaluate expression \'<% ctx().y.value %>\'. '
-                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().y.value %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#value"'
                 )
             }
         ]

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_error_handling.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_error_handling.py
@@ -56,6 +56,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().y.value %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#value"'
@@ -110,6 +111,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().y.value %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#value"'
@@ -160,6 +162,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -223,6 +226,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -231,6 +235,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
                 'task_transition_id': 'task3__0'
             },
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#foobar"'
@@ -291,6 +296,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -347,6 +353,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().y.value %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#value"'
@@ -395,6 +402,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -438,6 +446,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -481,6 +490,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -531,6 +541,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -576,6 +587,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -621,6 +633,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -676,6 +689,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -683,6 +697,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
                 'task_id': 'task1'
             },
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#foobar"'
@@ -733,6 +748,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -740,6 +756,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
                 'task_id': 'task1'
             },
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#foobar"'
@@ -786,6 +803,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().foobar.fubar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#fubar"'
@@ -793,6 +811,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
                 'task_id': 'task2'
             },
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().fubar.foobar %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#foobar"'
@@ -862,6 +881,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         expected_errors = [
             {
+                'type': 'error',
                 'message': (
                     'Unable to evaluate expression \'<% ctx().y.value %>\'. '
                     'NoFunctionRegisteredException: Unknown function "#property#value"'

--- a/orquesta/tests/unit/specs/native/test_workflow_spec.py
+++ b/orquesta/tests/unit/specs/native/test_workflow_spec.py
@@ -150,7 +150,7 @@ class WorkflowSpecTest(base.OrchestraWorkflowSpecTest):
 
         self.assertListEqual(
             wf_spec.tasks.get_start_tasks(),
-            [('task1', None)]
+            [('task1', None, None)]
         )
 
     def test_is_join_task(self):

--- a/orquesta/tests/unit/utils/test_dictionary.py
+++ b/orquesta/tests/unit/utils/test_dictionary.py
@@ -128,3 +128,83 @@ class DictUtilsTest(unittest.TestCase):
             'a.b',
             raise_key_error=True
         )
+
+    def test_dict_dot_notation_set_value(self):
+        data = {
+            'a': 'foo',
+            'b': {
+                'c': 'bar',
+                'd': {
+                    'e': 123,
+                    'f': False,
+                    'g': {},
+                    'h': None
+                }
+            },
+            'x': {},
+            'y': None
+        }
+
+        # Test basic insert.
+        utils.set_dict_value(data, 'z', {'foo': 'bar'})
+
+        # Test insert via dot notation on existing node.
+        utils.set_dict_value(data, 'b.d.h', 2.0)
+
+        # Test insert via dot notation on nonexistent nodes.
+        utils.set_dict_value(data, 'm.n.o', True)
+
+        # Test insert non-null only.
+        utils.set_dict_value(data, 'b.d.i', None, insert_null=False)
+
+        # Test insert null.
+        utils.set_dict_value(data, 'b.d.j', None, insert_null=True)
+
+        expected_data = {
+            'a': 'foo',
+            'b': {
+                'c': 'bar',
+                'd': {
+                    'e': 123,
+                    'f': False,
+                    'g': {},
+                    'h': 2.0,
+                    'j': None
+                }
+            },
+            'm': {
+                'n': {
+                    'o': True
+                }
+            },
+            'x': {},
+            'y': None,
+            'z': {
+                'foo': 'bar'
+            }
+        }
+
+        self.assertDictEqual(data, expected_data)
+
+    def test_dict_dot_notation_set_value_type_error(self):
+        data = {'a': 'foo'}
+
+        self.assertRaises(
+            TypeError,
+            utils.set_dict_value,
+            data,
+            'a.b',
+            'foobar'
+        )
+
+    def test_dict_dot_notation_set_value_key_error(self):
+        data = {'a': {}}
+
+        self.assertRaises(
+            KeyError,
+            utils.set_dict_value,
+            data,
+            'a.b',
+            'foobar',
+            raise_key_error=True
+        )

--- a/orquesta/utils/dictionary.py
+++ b/orquesta/utils/dictionary.py
@@ -36,10 +36,9 @@ def merge_dicts(left, right, overwrite=True):
 
 def get_dict_value(obj, path, raise_key_error=False):
     item = obj
-    keys = path.split('.')
     traversed = ''
 
-    for key in keys:
+    for key in path.split('.'):
         if not isinstance(item, dict) and traversed != path:
             raise TypeError('Value of \'%s\' is not typeof dict.' % traversed)
 
@@ -54,3 +53,28 @@ def get_dict_value(obj, path, raise_key_error=False):
             break
 
     return item
+
+
+def set_dict_value(obj, path, value, raise_key_error=False, insert_null=True):
+    if not insert_null and value is None:
+        return
+
+    item = obj
+    traversed = ''
+
+    for key in path.split('.'):
+        if not isinstance(item, dict) and traversed != path:
+            raise TypeError('Value of \'%s\' is not typeof dict.' % traversed)
+
+        traversed += '.' + key if len(traversed) > 0 else key
+
+        if key not in item and raise_key_error:
+            raise KeyError('Key \'%s\' does not exist.' % traversed)
+
+        if traversed == path:
+            item[key] = value
+        else:
+            if key not in item:
+                item[key] = {}
+
+            item = item[key]


### PR DESCRIPTION
Refactor the native workflow composer and workflow graph to allow more than one transition between two tasks. Add a reference ID as attribute of the edge in the graph that correspond to the index of the transition in the task spec. Refactor finalize_context in task spec to require addition task transition information as input. For the native model, the task spec uses the ref attribute stored in the edge's list of attributes to identify the task transition spec precisely. Previously, the method compares the criteria string which is not precise and bug prone.