### PR TITLE
Process workflow output in other completed states

### DIFF
--- a/orquesta/tests/unit/conducting/test_workflow_conductor.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor.py
@@ -656,8 +656,9 @@ class WorkflowConductorTest(base.WorkflowConductorTest):
         conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.RUNNING))
         conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.FAILED))
 
+        expected_output = {'data': {'a': 123, 'b': True, 'c': 'xyz'}}
         self.assertEqual(conductor.get_workflow_state(), states.FAILED)
-        self.assertIsNone(conductor.get_workflow_output())
+        self.assertDictEqual(conductor.get_workflow_output(), expected_output)
 
     def test_get_workflow_output_when_workflow_succeeded(self):
         inputs = {'a': 123, 'b': True}

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_error_handling.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_error_handling.py
@@ -870,6 +870,17 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
             action: core.noop
         """
 
+        expected_errors = [
+            {
+                'type': 'error',
+                'message': (
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% result().foobar %>\'. ExpressionEvaluationException: '
+                    'The current task is not set in the context.'
+                )
+            }
+        ]
+
         spec = specs.WorkflowSpec(wf_def)
         self.assertDictEqual(spec.inspect(), {})
 
@@ -882,6 +893,7 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
         conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.SUCCEEDED))
 
         self.assertEqual(conductor.get_workflow_state(), states.FAILED)
+        self.assertListEqual(conductor.errors, expected_errors)
         self.assertIsNone(conductor.get_workflow_output())
 
     def test_workflow_output_seq_ref_error(self):
@@ -897,6 +909,11 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
           task1:
             action: core.noop
         """
+
+        expected_output = {
+            'x': 123,
+            'y': 123
+        }
 
         expected_errors = [
             {
@@ -922,4 +939,4 @@ class WorkflowConductorErrorHandlingTest(base.WorkflowConductorTest):
 
         self.assertEqual(conductor.get_workflow_state(), states.FAILED)
         self.assertListEqual(conductor.errors, expected_errors)
-        self.assertIsNone(conductor.get_workflow_output())
+        self.assertDictEqual(conductor.get_workflow_output(), expected_output)

--- a/orquesta/tests/unit/specs/native/test_workflow_spec_validate_vars.py
+++ b/orquesta/tests/unit/specs/native/test_workflow_spec_validate_vars.py
@@ -646,3 +646,27 @@ class WorkflowSpecVarsValidationTest(base.OrchestraWorkflowSpecTest):
         wf_spec = self.instantiate(wf_def)
 
         self.assertDictEqual(wf_spec.inspect(), {})
+
+    def test_vars_in_output_on_error_handling(self):
+        wf_def = """
+            version: 1.0
+            description: A basic sequential workflow.
+            input:
+              - a
+            output:
+              - b: <% ctx().b %>
+              - x: <% ctx().a %>
+              - y: <% ctx().x %>
+              - z: <% ctx().x %> <% ctx().y %>
+            tasks:
+              task1:
+                action: core.noop
+                next:
+                  - when: <% failed() %>
+                    publish: b="foobar"
+                    do: fail
+        """
+
+        wf_spec = self.instantiate(wf_def)
+
+        self.assertDictEqual(wf_spec.inspect(), {})


### PR DESCRIPTION
Previously, workflow output is processed only when workflow succeeds. This patch enables workflow output to be processed when workflow completes, regardless of success or failure. If there is a evaluation error, the line item in the output will be skipped and evaluation error recorded. When there is an output evaluation error, the workflow will be marked as failed.