### PR TITLE
Fix state change when workflow output fails rendering

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -42,3 +42,9 @@ provider relays the status and result back to the conductor. The conductor then 
 change, keeps track of the sequence of task execution, manages change history of the runtime
 context, evaluate outbound task transitions, identifies any new tasks for execution, and determines
 the overall workflow state and result.
+
+When there is no more tasks identified to run next, the workflow is complete. On workflow
+completion, regardless of state, the workflow result contains the list of error(s) if any and the
+output as defined in the workflow defintion. If the workflow failed, the workflow conductor will do
+its best to render the output from the latest version of the runtime context at completion of the
+workflow execution.

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -326,8 +326,10 @@ class WorkflowConductor(object):
                 term_ctx_entry['value'] = term_ctx_val
 
     def _render_workflow_outputs(self):
+        wf_state = self.get_workflow_state()
+
         # Render workflow outputs if workflow is completed.
-        if self.get_workflow_state() in states.COMPLETED_STATES and not self._outputs:
+        if wf_state in states.COMPLETED_STATES and not self._outputs:
             workflow_context = self.get_workflow_terminal_context()['value']
             outputs, errors = self.spec.render_output(workflow_context)
 
@@ -338,7 +340,9 @@ class WorkflowConductor(object):
             # Log errors if any returned and mark workflow as failed.
             if errors:
                 self.log_errors(errors)
-                self.request_workflow_state(states.FAILED)
+
+                if wf_state not in [states.EXPIRED, states.ABANDONED, states.CANCELED]:
+                    self.request_workflow_state(states.FAILED)
 
     def get_workflow_output(self):
         return copy.deepcopy(self._outputs) if self._outputs else None

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_cancel.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_cancel.py
@@ -1,0 +1,106 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orquesta import conducting
+from orquesta import events
+from orquesta.specs import native as specs
+from orquesta import states
+from orquesta.tests.unit import base
+
+
+class WorkflowConductorCancelTest(base.WorkflowConductorTest):
+
+    def test_workflow_output(self):
+        wf_def = """
+        version: 1.0
+
+        output:
+          - x: 123
+          - y: <% ctx().x %>
+
+        tasks:
+          task1:
+            action: core.noop
+        """
+
+        expected_output = {
+            'x': 123,
+            'y': 123
+        }
+
+        expected_errors = []
+
+        spec = specs.WorkflowSpec(wf_def)
+        self.assertDictEqual(spec.inspect(), {})
+
+        # Run the workflow and keep it running.
+        conductor = conducting.WorkflowConductor(spec)
+        conductor.request_workflow_state(states.RUNNING)
+        task_name = 'task1'
+        conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.RUNNING))
+
+        # Cancels the workflow and complete task1.
+        conductor.request_workflow_state(states.CANCELING)
+        conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.SUCCEEDED))
+
+        # Check workflow status and output.
+        self.assertEqual(conductor.get_workflow_state(), states.CANCELED)
+        self.assertListEqual(conductor.errors, expected_errors)
+        self.assertDictEqual(conductor.get_workflow_output(), expected_output)
+
+    def test_workflow_output_with_error(self):
+        wf_def = """
+        version: 1.0
+
+        output:
+          - x: 123
+          - y: <% ctx().x %>
+          - z: <% ctx().y.value %>
+
+        tasks:
+          task1:
+            action: core.noop
+        """
+
+        expected_output = {
+            'x': 123,
+            'y': 123
+        }
+
+        expected_errors = [
+            {
+                'type': 'error',
+                'message': (
+                    'YaqlEvaluationException: Unable to evaluate expression '
+                    '\'<% ctx().y.value %>\'. NoFunctionRegisteredException: '
+                    'Unknown function "#property#value"'
+                )
+            }
+        ]
+
+        spec = specs.WorkflowSpec(wf_def)
+        self.assertDictEqual(spec.inspect(), {})
+
+        # Run the workflow and keep it running.
+        conductor = conducting.WorkflowConductor(spec)
+        conductor.request_workflow_state(states.RUNNING)
+        task_name = 'task1'
+        conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.RUNNING))
+
+        # Cancels the workflow and complete task1.
+        conductor.request_workflow_state(states.CANCELING)
+        conductor.update_task_flow(task_name, events.ActionExecutionEvent(states.SUCCEEDED))
+
+        # Check workflow status is not changed to failed given the output error.
+        self.assertEqual(conductor.get_workflow_state(), states.CANCELED)
+        self.assertListEqual(conductor.errors, expected_errors)
+        self.assertDictEqual(conductor.get_workflow_output(), expected_output)


### PR DESCRIPTION
If a workflow is already expired, abandoned, or canceled and there are errors rendering workflow output, keep the workflow state as is and don't change it to failed.