### PR TITLE
Add delay property to task model of native spec

### DIFF
--- a/docs/source/expressions.rst
+++ b/docs/source/expressions.rst
@@ -59,6 +59,8 @@ The following are attributes in the **Task** model that accept expressions:
 +--------------+----------------------------------+
 | Attributes   | Accept Expressions               |
 +==============+==================================+
+| delay        | Yes                              |
++--------------+----------------------------------+
 | join         | No                               |
 +--------------+----------------------------------+
 | with         | Yes, see With Items              |

--- a/docs/source/languages/orquesta.rst
+++ b/docs/source/languages/orquesta.rst
@@ -78,6 +78,8 @@ Task Model
 +-------------+-------------+-------------------------------------------------------------------+
 | Attribute   | Required    | Description                                                       |
 +=============+=============+===================================================================+
+| delay       | No          | If specified, the number of seconds to delay the task execution.  |
++-------------+-------------+-------------------------------------------------------------------+
 | join        | No          | If specified, sets up a barrier for a group of parallel branches. |
 +-------------+-------------+-------------------------------------------------------------------+
 | with        | No          | When given a list, execute the action for each item.              |
@@ -274,8 +276,8 @@ tasks and task transitions:
             # variables to be published based on the task state and
             # its result.
             publish:
-              msg: task1 done
-              ab: <% result() %>
+              - msg: task1 done
+              - ab: <% result() %>
 
             # List the tasks to run next. Each task will be invoked
             # sequentially. If more than one tasks transition to the
@@ -437,4 +439,4 @@ The following example illustrates the use of the ``fail`` command:
           - do: fail
 
     output:
-      - result: <% $.stdout %>
+      - result: <% ctx(stdout) %>

--- a/docs/source/schemas/orquesta.json
+++ b/docs/source/schemas/orquesta.json
@@ -12,10 +12,6 @@
                     "additionalProperties": false, 
                     "type": "object", 
                     "properties": {
-                        "action": {
-                            "minLength": 1, 
-                            "type": "string"
-                        }, 
                         "join": {
                             "oneOf": [
                                 {
@@ -26,67 +22,6 @@
                                 {
                                     "minimum": 0, 
                                     "type": "integer"
-                                }
-                            ]
-                        }, 
-                        "with": {
-                            "type": "object", 
-                            "properties": {
-                                "items": {
-                                    "minLength": 1, 
-                                    "type": "string", 
-                                    "pattern": "^(\\s+)?({{.*?}}|<%.*?%>)(\\s+)?$|^(\\s+)?((\\w+,\\s?|\\s+)+)?(\\w+)\\s+in\\s+({{.*?}}|<%.*?%>)(\\s+)?$"
-                                }, 
-                                "concurrency": {
-                                    "oneOf": [
-                                        {
-                                            "minLength": 1, 
-                                            "type": "string"
-                                        }, 
-                                        {
-                                            "minimum": 0, 
-                                            "type": "integer"
-                                        }
-                                    ]
-                                }
-                            }
-                        }, 
-                        "input": {
-                            "oneOf": [
-                                {
-                                    "minLength": 1, 
-                                    "type": "string"
-                                }, 
-                                {
-                                    "type": "object", 
-                                    "patternProperties": {
-                                        "^\\w+$": {
-                                            "anyOf": [
-                                                {
-                                                    "type": "null"
-                                                }, 
-                                                {
-                                                    "type": "array"
-                                                }, 
-                                                {
-                                                    "type": "boolean"
-                                                }, 
-                                                {
-                                                    "type": "integer"
-                                                }, 
-                                                {
-                                                    "type": "number"
-                                                }, 
-                                                {
-                                                    "type": "object"
-                                                }, 
-                                                {
-                                                    "type": "string"
-                                                }
-                                            ]
-                                        }
-                                    }, 
-                                    "minProperties": 1
                                 }
                             ]
                         }, 
@@ -164,6 +99,83 @@
                                 }
                             }, 
                             "type": "array"
+                        }, 
+                        "delay": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "minimum": 0, 
+                                    "type": "integer"
+                                }
+                            ]
+                        }, 
+                        "action": {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        "input": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "type": "object", 
+                                    "patternProperties": {
+                                        "^\\w+$": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "null"
+                                                }, 
+                                                {
+                                                    "type": "array"
+                                                }, 
+                                                {
+                                                    "type": "boolean"
+                                                }, 
+                                                {
+                                                    "type": "integer"
+                                                }, 
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "type": "object"
+                                                }, 
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ]
+                                        }
+                                    }, 
+                                    "minProperties": 1
+                                }
+                            ]
+                        }, 
+                        "with": {
+                            "type": "object", 
+                            "properties": {
+                                "items": {
+                                    "minLength": 1, 
+                                    "type": "string", 
+                                    "pattern": "^(\\s+)?({{.*?}}|<%.*?%>)(\\s+)?$|^(\\s+)?((\\w+,\\s?|\\s+)+)?(\\w+)\\s+in\\s+({{.*?}}|<%.*?%>)(\\s+)?$"
+                                }, 
+                                "concurrency": {
+                                    "oneOf": [
+                                        {
+                                            "minLength": 1, 
+                                            "type": "string"
+                                        }, 
+                                        {
+                                            "minimum": 0, 
+                                            "type": "integer"
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     }
                 }

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -403,6 +403,19 @@ class WorkflowConductor(object):
             'actions': action_specs
         }
 
+        # If there is a task delay specified, evaluate the delay value.
+        if getattr(task_spec, 'delay', None):
+            task_delay = task_spec.delay
+
+            if isinstance(task_delay, six.string_types):
+                task_delay = expr.evaluate(task_delay, task_ctx)
+
+            if not isinstance(task_delay, int):
+                raise TypeError('The value of task delay is not type of integer.')
+
+            task['delay'] = task_delay
+
+        # Add items and related meta data to the task details.
         if task_spec.has_items():
             items_spec = getattr(task_spec, 'with')
             task['items_count'] = len(action_specs)

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -122,6 +122,7 @@ class TaskSpec(base.Spec):
     _schema = {
         'type': 'object',
         'properties': {
+            'delay': types.STRING_OR_POSITIVE_INTEGER,
             'join': {
                 'oneOf': [
                     {'enum': ['all']},
@@ -142,6 +143,7 @@ class TaskSpec(base.Spec):
     }
 
     _context_evaluation_sequence = [
+        'delay',
         'with',
         'action',
         'input',

--- a/orquesta/tests/unit/base.py
+++ b/orquesta/tests/unit/base.py
@@ -139,7 +139,7 @@ class WorkflowComposerTest(WorkflowGraphTest, WorkflowSpecTest):
 class WorkflowConductorTest(WorkflowComposerTest):
 
     def format_task_item(self, task_name, task_init_ctx, task_spec,
-                         action_specs=None, task_id=None,
+                         action_specs=None, task_id=None, task_delay=None,
                          items_count=None, items_concurrency=None):
 
         if not action_specs:
@@ -157,6 +157,9 @@ class WorkflowConductorTest(WorkflowComposerTest):
             'spec': task_spec,
             'actions': action_specs
         }
+
+        if task_delay:
+            task['delay'] = task_delay
 
         if items_count:
             task['items_count'] = items_count


### PR DESCRIPTION
Add delay property to task model of native spec. The delay property specifies how many seconds to wait before the task and subsequent action execution.