### PR TITLE
 Fix conductor get next tasks for with items task with empty list

### DIFF
--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -490,6 +490,8 @@ class WorkflowConductor(object):
 
                     if 'actions' in next_task and len(next_task['actions']) > 0:
                         next_tasks.append(next_task)
+                    elif 'items_count' in next_task and next_task['items_count'] == 0:
+                        next_tasks.append(next_task)
                 except Exception as e:
                     self.log_error(e, task_id=staged_task_id)
                     self.request_workflow_state(states.FAILED)
@@ -525,6 +527,8 @@ class WorkflowConductor(object):
                     next_task = self._evaluate_task_actions(next_task)
 
                     if 'actions' in next_task and len(next_task['actions']) > 0:
+                        next_tasks.append(next_task)
+                    elif 'items_count' in next_task and next_task['items_count'] == 0:
                         next_tasks.append(next_task)
                 except Exception as e:
                     self.log_error(e, task_id=next_task_id)

--- a/orquesta/tests/fixtures/workflows/native/splits-mixed.yaml
+++ b/orquesta/tests/fixtures/workflows/native/splits-mixed.yaml
@@ -1,0 +1,37 @@
+version: 1.0
+  
+description: >
+  A basic workflow that demonstrate a split use case where a non-join task
+  is referenced in more than one task transitions. The workflow is hence
+  split into multiple branches from the non-join task. Additional splits
+  occur at task transitions.
+
+tasks:
+  task1:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task3
+  task2:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task3
+
+  # split from single task transition in a task
+  task3:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task4
+      - when: <% failed() %>
+        do: task4
+
+  # split from multiple task transition in a task
+  task4:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task5
+  task5:
+    action: core.noop

--- a/orquesta/tests/unit/conducting/native/test_workflow_split.py
+++ b/orquesta/tests/unit/conducting/native/test_workflow_split.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from orquesta import states
 from orquesta.tests.unit.conducting.native import base
 
 
@@ -117,3 +118,57 @@ class SplitWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
         self.assert_spec_inspection(wf_name)
 
         self.assert_conducting_sequences(wf_name, expected_task_seq)
+
+    def test_splits_mixed(self):
+        wf_name = 'splits-mixed'
+
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task3__1',
+            'task3__2',
+            'task4__1',
+            'task4__3',
+            'task5__1',
+            'task5__3'
+        ]
+
+        self.assert_spec_inspection(wf_name)
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq
+        )
+
+    def test_splits_mixed_alt_branch(self):
+        wf_name = 'splits-mixed'
+
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task3__1',
+            'task3__2',
+            'task4__1',
+            'task4__4',
+            'task5__1',
+            'task5__4'
+        ]
+
+        mock_states = [
+            states.SUCCEEDED,   # task1
+            states.SUCCEEDED,   # task2
+            states.SUCCEEDED,   # task3__1
+            states.FAILED,      # task3__2
+            states.SUCCEEDED,   # task4__1
+            states.SUCCEEDED,   # task4__4
+            states.SUCCEEDED,   # task5__1
+            states.SUCCEEDED    # task5__4
+        ]
+
+        self.assert_spec_inspection(wf_name)
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_states=mock_states
+        )


### PR DESCRIPTION
Fix a condition for with items task where the items list is empty. Before the patch, when the conductor get next tasks, the with items task will not be included in next tasks because the list is empty. The conductor is refactored to return the with items task in next tasks but without any action specs. The service using conductor will have to handle this accordingly to complete the with items task appropriately. The reasoning here is that the service such as StackStorm also maintains DB records for the task execution. Therefore, the conductor cannot auto forward to the next task but let the service manually handle the task execution even though the items list is empty and then manually forward the workflow progress.