### PR TITLE
Add get_routes function to workflow graph

### DIFF
--- a/orquesta/tests/unit/base.py
+++ b/orquesta/tests/unit/base.py
@@ -67,6 +67,11 @@ class WorkflowGraphTest(unittest.TestCase):
 
         self.assertListEqual(wf_graph_meta, expected_wf_graph_meta)
 
+        wf_graph_attrs = sorted(wf_graph_json['graph'], key=lambda x: x[0])
+        expected_wf_graph_attrs = sorted(expected_wf_graph['graph'], key=lambda x: x[0])
+
+        self.assertListEqual(wf_graph_attrs, expected_wf_graph_attrs)
+
 
 class WorkflowSpecTest(unittest.TestCase):
     spec_module_name = 'mock'

--- a/orquesta/tests/unit/composition/native/base.py
+++ b/orquesta/tests/unit/composition/native/base.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
 from orquesta.tests.unit import base
 
 
@@ -19,3 +21,11 @@ class OrchestraWorkflowComposerTest(base.WorkflowComposerTest):
     def setUpClass(cls):
         cls.spec_module_name = 'native'
         super(OrchestraWorkflowComposerTest, cls).setUpClass()
+
+    def assert_wf_ex_routes(self, wf_name, expected_routes, debug=False):
+        wf_ex_graph = self.compose_wf_ex_graph(wf_name)
+
+        if debug:
+            print(json.dumps(wf_ex_graph.get_routes(), indent=4))
+
+        self.assertListEqual(wf_ex_graph.get_routes(), expected_routes)

--- a/orquesta/tests/unit/graphing/native/test_routes_basic.py
+++ b/orquesta/tests/unit/graphing/native/test_routes_basic.py
@@ -1,0 +1,132 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orquesta.tests.unit.composition.native import base
+
+
+class BasicWorkflowRoutesTest(base.OrchestraWorkflowComposerTest):
+
+    def test_sequential(self):
+        wf_name = 'sequential'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'noop',
+                    'task1',
+                    'task2',
+                    'task3'
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task2', 'task3', 0),
+                    ('task3', 'noop', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_parallel(self):
+        wf_name = 'parallel'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2',
+                    'task3'
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task2', 'task3', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task4',
+                    'task5',
+                    'task6'
+                ],
+                'path': [
+                    ('task4', 'task5', 0),
+                    ('task5', 'task6', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_branching(self):
+        wf_name = 'branching'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2',
+                    'task3'
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task2', 'task3', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task4',
+                    'task5'
+                ],
+                'path': [
+                    ('task1', 'task4', 0),
+                    ('task4', 'task5', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_decision(self):
+        wf_name = 'decision'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'a',
+                    't1'
+                ],
+                'path': [
+                    ('t1', 'a', 0),
+                ]
+            },
+            {
+                'tasks': [
+                    'b',
+                    't1'
+                ],
+                'path': [
+                    ('t1', 'b', 0),
+                ]
+            },
+            {
+                'tasks': [
+                    'c',
+                    't1'
+                ],
+                'path': [
+                    ('t1', 'c', 0),
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)

--- a/orquesta/tests/unit/graphing/native/test_routes_cycle.py
+++ b/orquesta/tests/unit/graphing/native/test_routes_cycle.py
@@ -1,0 +1,65 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orquesta.tests.unit.composition.native import base
+
+
+class CyclicWorkflowRoutesTest(base.OrchestraWorkflowComposerTest):
+
+    def test_cycle(self):
+        wf_name = 'cycle'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'prep',
+                    'task1',
+                    'task2',
+                    'task3'
+                ],
+                'path': [
+                    ('prep', 'task1', 0),
+                    ('task1', 'task2', 0),
+                    ('task2', 'task3', 0),
+                    ('task3', 'task1', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_cycles(self):
+        wf_name = 'cycles'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'prep',
+                    'task1',
+                    'task2',
+                    'task3',
+                    'task4',
+                    'task5'
+                ],
+                'path': [
+                    ('prep', 'task1', 0),
+                    ('task1', 'task2', 0),
+                    ('task2', 'task3', 0),
+                    ('task2', 'task5', 0),
+                    ('task3', 'task4', 0),
+                    ('task4', 'task2', 0),
+                    ('task5', 'task1', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)

--- a/orquesta/tests/unit/graphing/native/test_routes_join.py
+++ b/orquesta/tests/unit/graphing/native/test_routes_join.py
@@ -1,0 +1,75 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orquesta.tests.unit.composition.native import base
+
+
+class JoinWorkflowRoutesTest(base.OrchestraWorkflowComposerTest):
+
+    def test_join(self):
+        wf_name = 'join'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2',
+                    'task3',
+                    'task4',
+                    'task5',
+                    'task6',
+                    'task7'
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task1', 'task4', 0),
+                    ('task2', 'task3', 0),
+                    ('task3', 'task6', 0),
+                    ('task4', 'task5', 0),
+                    ('task5', 'task6', 0),
+                    ('task6', 'task7', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_join_count(self):
+        wf_name = 'join-count'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2',
+                    'task3',
+                    'task4',
+                    'task5',
+                    'task6',
+                    'task7',
+                    'task8'
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task1', 'task4', 0),
+                    ('task1', 'task6', 0),
+                    ('task2', 'task3', 0),
+                    ('task3', 'task8', 0),
+                    ('task4', 'task5', 0),
+                    ('task5', 'task8', 0),
+                    ('task6', 'task7', 0),
+                    ('task7', 'task8', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)

--- a/orquesta/tests/unit/graphing/native/test_routes_split.py
+++ b/orquesta/tests/unit/graphing/native/test_routes_split.py
@@ -1,0 +1,263 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orquesta.tests.unit.composition.native import base
+
+
+class SplitWorkflowRoutesTest(base.OrchestraWorkflowComposerTest):
+
+    def test_split(self):
+        wf_name = 'split'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2',
+                    'task4__1',
+                    'task5__1',
+                    'task6__1',
+                    'task7__1',
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task2', 'task4__1', 0),
+                    ('task4__1', 'task5__1', 0),
+                    ('task4__1', 'task6__1', 0),
+                    ('task5__1', 'task7__1', 0),
+                    ('task6__1', 'task7__1', 0),
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task3',
+                    'task4__2',
+                    'task5__2',
+                    'task6__2',
+                    'task7__2'
+                ],
+                'path': [
+                    ('task1', 'task3', 0),
+                    ('task3', 'task4__2', 0),
+                    ('task4__2', 'task5__2', 0),
+                    ('task4__2', 'task6__2', 0),
+                    ('task5__2', 'task7__2', 0),
+                    ('task6__2', 'task7__2', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_splits(self):
+        wf_name = 'splits'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task8__1'
+                ],
+                'path': [
+                    ('task1', 'task8__1', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task2',
+                    'task4__1',
+                    'task5__1',
+                    'task6__1',
+                    'task7__1',
+                    'task8__2'
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task2', 'task4__1', 0),
+                    ('task4__1', 'task5__1', 0),
+                    ('task4__1', 'task6__1', 0),
+                    ('task5__1', 'task7__1', 0),
+                    ('task6__1', 'task7__1', 0),
+                    ('task7__1', 'task8__2', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task3',
+                    'task4__2',
+                    'task5__2',
+                    'task6__2',
+                    'task7__2',
+                    'task8__3'
+                ],
+                'path': [
+                    ('task1', 'task3', 0),
+                    ('task3', 'task4__2', 0),
+                    ('task4__2', 'task5__2', 0),
+                    ('task4__2', 'task6__2', 0),
+                    ('task5__2', 'task7__2', 0),
+                    ('task6__2', 'task7__2', 0),
+                    ('task7__2', 'task8__3', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_nested_splits(self):
+        wf_name = 'splits-nested'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task10__1',
+                    'task2',
+                    'task4__1',
+                    'task5__1',
+                    'task7__1',
+                    'task8__1',
+                    'task9__1'
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task2', 'task4__1', 0),
+                    ('task4__1', 'task5__1', 0),
+                    ('task5__1', 'task7__1', 0),
+                    ('task7__1', 'task8__1', 0),
+                    ('task7__1', 'task9__1', 0),
+                    ('task8__1', 'task10__1', 0),
+                    ('task9__1', 'task10__1', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task10__2',
+                    'task2',
+                    'task4__1',
+                    'task6__1',
+                    'task7__2',
+                    'task8__2',
+                    'task9__2'
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task2', 'task4__1', 0),
+                    ('task4__1', 'task6__1', 0),
+                    ('task6__1', 'task7__2', 0),
+                    ('task7__2', 'task8__2', 0),
+                    ('task7__2', 'task9__2', 0),
+                    ('task8__2', 'task10__2', 0),
+                    ('task9__2', 'task10__2', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task10__3',
+                    'task3',
+                    'task4__2',
+                    'task5__2',
+                    'task7__3',
+                    'task8__3',
+                    'task9__3'
+                ],
+                'path': [
+                    ('task1', 'task3', 0),
+                    ('task3', 'task4__2', 0),
+                    ('task4__2', 'task5__2', 0),
+                    ('task5__2', 'task7__3', 0),
+                    ('task7__3', 'task8__3', 0),
+                    ('task7__3', 'task9__3', 0),
+                    ('task8__3', 'task10__3', 0),
+                    ('task9__3', 'task10__3', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task10__4',
+                    'task3',
+                    'task4__2',
+                    'task6__2',
+                    'task7__4',
+                    'task8__4',
+                    'task9__4'
+                ],
+                'path': [
+                    ('task1', 'task3', 0),
+                    ('task3', 'task4__2', 0),
+                    ('task4__2', 'task6__2', 0),
+                    ('task6__2', 'task7__4', 0),
+                    ('task7__4', 'task8__4', 0),
+                    ('task7__4', 'task9__4', 0),
+                    ('task8__4', 'task10__4', 0),
+                    ('task9__4', 'task10__4', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_splits_extra_join(self):
+        wf_name = 'splits-join'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2',
+                    'task4__1',
+                    'task5__1',
+                    'task6__1',
+                    'task7__1',
+                    'task8__1'
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task1', 'task8__1', 0),
+                    ('task2', 'task4__1', 0),
+                    ('task4__1', 'task5__1', 0),
+                    ('task4__1', 'task6__1', 0),
+                    ('task5__1', 'task7__1', 0),
+                    ('task6__1', 'task7__1', 0),
+                    ('task7__1', 'task8__1', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task3',
+                    'task4__2',
+                    'task5__2',
+                    'task6__2',
+                    'task7__2',
+                    'task8__2'
+                ],
+                'path': [
+                    ('task1', 'task3', 0),
+                    ('task1', 'task8__2', 0),
+                    ('task3', 'task4__2', 0),
+                    ('task4__2', 'task5__2', 0),
+                    ('task4__2', 'task6__2', 0),
+                    ('task5__2', 'task7__2', 0),
+                    ('task6__2', 'task7__2', 0),
+                    ('task7__2', 'task8__2', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)

--- a/orquesta/tests/unit/graphing/native/test_routes_task_transition.py
+++ b/orquesta/tests/unit/graphing/native/test_routes_task_transition.py
@@ -1,0 +1,164 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orquesta.tests.unit.composition.native import base
+
+
+class TaskTransitionWorkflowRoutesTest(base.OrchestraWorkflowComposerTest):
+
+    def test_error_handling(self):
+        wf_name = 'error-handling'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2'
+                ],
+                'path': [
+                    ('task1', 'task2', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task3'
+                ],
+                'path': [
+                    ('task1', 'task3', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_task_with_duplicate_when(self):
+        wf_name = 'task-duplicate-when'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2'
+                ],
+                'path': [
+                    ('task1', 'task2', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task3'
+                ],
+                'path': [
+                    ('task1', 'task3', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_task_with_duplicate_transition(self):
+        wf_name = 'task-duplicate-transition'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2__1'
+                ],
+                'path': [
+                    ('task1', 'task2__1', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task2__2'
+                ],
+                'path': [
+                    ('task1', 'task2__2', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_on_complete(self):
+        wf_name = 'task-on-complete'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2'
+                ],
+                'path': [
+                    ('task1', 'task2', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task3'
+                ],
+                'path': [
+                    ('task1', 'task3', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task4'
+                ],
+                'path': [
+                    ('task1', 'task4', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)
+
+    def test_task_transitions_split(self):
+        wf_name = 'task-transitions-split'
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2__1'
+                ],
+                'path': [
+                    ('task1', 'task2__1', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task2__2'
+                ],
+                'path': [
+                    ('task1', 'task2__2', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task2__3'
+                ],
+                'path': [
+                    ('task1', 'task2__3', 0)
+                ]
+            }
+        ]
+
+        self.assert_wf_ex_routes(wf_name, expected_routes)

--- a/orquesta/tests/unit/graphing/test_workflow_graph.py
+++ b/orquesta/tests/unit/graphing/test_workflow_graph.py
@@ -155,6 +155,18 @@ class WorkflowGraphTest(base.WorkflowGraphTest):
 
         self.assertListEqual(wf_graph.roots, expected)
 
+    def test_graph_leaves(self):
+        wf_graph = self._prep_graph()
+
+        expected_leaves = [{'id': 'task6', 'name': 'task6'}, {'id': 'task9', 'name': 'task9'}]
+
+        self.assertListEqual(wf_graph.leaves, expected_leaves)
+
+        # Ensure the underlying graph is not permanently altered.
+        expected_roots = [{'id': 'task1', 'name': 'task1'}]
+
+        self.assertListEqual(wf_graph.roots, expected_roots)
+
     def test_skip_add_tasks(self):
         wf_graph = graphing.WorkflowGraph()
 
@@ -347,3 +359,73 @@ class WorkflowGraphTest(base.WorkflowGraphTest):
             len(wf_graph.get_prev_transitions('task9')) > 1 and
             not wf_graph.has_barrier('task9')
         )
+
+    def test_get_route_bad_leaves(self):
+        wf_graph = self._prep_graph()
+
+        self.assertIsNone(wf_graph.get_route('task1'))
+        self.assertIsNone(wf_graph.get_route('task101'))
+
+    def test_get_route(self):
+        wf_graph = self._prep_graph()
+
+        expected_route = {
+            'tasks': [
+                'task1',
+                'task2',
+                'task3',
+                'task4',
+                'task5',
+                'task6'
+            ],
+            'path': [
+                ('task1', 'task2', 0),
+                ('task1', 'task4', 0),
+                ('task2', 'task3', 0),
+                ('task3', 'task5', 0),
+                ('task4', 'task5', 0),
+                ('task5', 'task6', 0)
+            ]
+        }
+
+        self.assertDictEqual(wf_graph.get_route('task6'), expected_route)
+
+    def test_get_routes(self):
+        wf_graph = self._prep_graph()
+
+        expected_routes = [
+            {
+                'tasks': [
+                    'task1',
+                    'task2',
+                    'task3',
+                    'task4',
+                    'task5',
+                    'task6'
+                ],
+                'path': [
+                    ('task1', 'task2', 0),
+                    ('task1', 'task4', 0),
+                    ('task2', 'task3', 0),
+                    ('task3', 'task5', 0),
+                    ('task4', 'task5', 0),
+                    ('task5', 'task6', 0)
+                ]
+            },
+            {
+                'tasks': [
+                    'task1',
+                    'task7',
+                    'task8',
+                    'task9'
+                ],
+                'path': [
+                    ('task1', 'task7', 0),
+                    ('task1', 'task9', 0),
+                    ('task7', 'task8', 0),
+                    ('task8', 'task9', 0)
+                ]
+            }
+        ]
+
+        self.assertListEqual(wf_graph.get_routes(), expected_routes)


### PR DESCRIPTION
Add a function in workflow graph to identify all possible routes as a function of the leaves or leaf clusters (closed cycles) in the graph.