### PR TITLE
Fix for variables containing 'in'

### DIFF
--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -183,8 +183,8 @@ class TaskSpec(base.Spec):
             items_spec = self.get_items_spec()
 
             items_expr = (
-                items_spec.items.strip() if 'in' not in items_spec.items
-                else items_spec.items[items_spec.items.index('in') + 2:].strip()
+                items_spec.items.strip() if ' in ' not in items_spec.items
+                else items_spec.items[items_spec.items.index(' in ') + 4:].strip()
             )
 
             items = expr.evaluate(items_expr, in_ctx)
@@ -193,8 +193,8 @@ class TaskSpec(base.Spec):
                 raise TypeError('The value of "%s" is not type of list.' % items_expr)
 
             item_keys = (
-                None if 'in' not in items_spec.items
-                else items_spec.items[:items_spec.items.index('in')].replace(' ', '').split(',')
+                None if ' in ' not in items_spec.items
+                else items_spec.items[:items_spec.items.index(' in ')].replace(' ', '').split(',')
             )
 
             for idx, item in enumerate(items):

--- a/orquesta/tests/unit/conducting/native/test_task_rendering_for_with_items.py
+++ b/orquesta/tests/unit/conducting/native/test_task_rendering_for_with_items.py
@@ -338,7 +338,7 @@ class WorkflowConductorWithItemsTaskRenderingTest(base.WorkflowConductorTest):
             next_task_ctx,
             next_task_spec,
             action_specs=next_task_action_specs,
-            items_count=len(next_task_ctx['xs']),
+            items_count=len(next_task_ctx['domains']),
             items_concurrency=None
         )
 


### PR DESCRIPTION
It's simple fix of the following issue

This workflow returns `TypeError: The value of "s) %>" is not type of list.` because "domains" contains 'in' 

```
version: 1.0

input:
  - domains

tasks:
  sk_update_domains:
    with:
      items: <% ctx(domains) %>
      concurency: 2
    action: i371.sk_update_domain domain=<% item() %>
```
