### PR TITLE
Failure to publish `True` to a variable using `shorthand format

### DIFF
--- a/orquesta/tests/unit/utils/test_parameters.py
+++ b/orquesta/tests/unit/utils/test_parameters.py
@@ -83,6 +83,19 @@ class InlineParametersTest(unittest.TestCase):
     def test_parse_null_type(self):
         self.assertListEqual(params.parse_inline_params(None), [])
 
+    def test_parse_bool_input(self):
+        tests = [
+            ('x=true', [{'x': True}]),
+            ('y=True', [{'y': True}]),
+            ('c=TRUE', [{'c': True}]),
+            ('x=false', [{'x': False}]),
+            ('y=False', [{'y': False}]),
+            ('c=FALSE', [{'c': False}])
+        ]
+
+        for s, d in tests:
+            self.assertListEqual(params.parse_inline_params(s), d)
+
     def test_parse_other_types(self):
         self.assertListEqual(params.parse_inline_params(123), [])
         self.assertListEqual(params.parse_inline_params(True), [])

--- a/orquesta/utils/parameters.py
+++ b/orquesta/utils/parameters.py
@@ -22,8 +22,8 @@ REGEX_VALUE_IN_QUOTES = '\"[^\"]*\"\s*'
 REGEX_VALUE_IN_APOSTROPHES = "'[^']*'\s*"
 REGEX_FLOATING_NUMBER = '[-]?\d*\.\d+'
 REGEX_INTEGER = '[-]?\d+'
-REGEX_TRUE = 'true'
-REGEX_FALSE = 'false'
+REGEX_TRUE = '(?i)true'
+REGEX_FALSE = '(?i)false'
 REGEX_NULL = 'null'
 
 # REGEX_FLOATING_NUMBER must go before REGEX_INTEGER
@@ -60,6 +60,9 @@ def parse_inline_params(s, preserve_order=True):
         # Remove leading and trailing single quotes.
         v = re.sub("^'", '', v)
         v = re.sub("'$", '', v)
+
+        if v.lower() == 'true' or v.lower() == 'false':
+            v = v.lower()
 
         # Load string into dictionary.
         try:


### PR DESCRIPTION
https://github.com/StackStorm/orquesta/issues/119
Failure to publish `True` to a variable using `shorthand format`
The root cause:
For this issue is that when `parse_inline_params` is called, it checks regular expression against `'true'` (`REGEX_TRUE = 'true'`).  Since input value is `True`. it returns empty list `v=[]`. This is why publish value always equals to input value which is `false`.

If modify expression to `REGEX_TRUE = '(?i)true'` to ignore case, it passes regular expression check and return `v=['True'], when later `v = json.loads(v)` is called, it treats `True` as string and publish output will be `"True"` instead of `true`.