### PR TITLE
Value in quotes in shorthand publish should be evaluated as string type

### DIFF
--- a/orquesta/tests/unit/utils/test_parameters.py
+++ b/orquesta/tests/unit/utils/test_parameters.py
@@ -108,6 +108,7 @@ class InlineParametersTest(unittest.TestCase):
             ("c='FALSE'", [{'c': 'FALSE'}]),
             ("d='123'", [{'d': '123'}]),
             ("e='abcde'", [{'e': 'abcde'}]),
+            ("f=''", [{'f': ''}])
         ]
 
         for s, d in tests:

--- a/orquesta/tests/unit/utils/test_parameters.py
+++ b/orquesta/tests/unit/utils/test_parameters.py
@@ -103,6 +103,7 @@ class InlineParametersTest(unittest.TestCase):
             ('c="TRUE"', [{'c': "TRUE"}]),
             ('d="123"', [{'d': '123'}]),
             ('e="abcde"', [{'e': 'abcde'}]),
+            ('f=""', [{'f': ''}]),
             ("x='false'", [{'x': 'false'}]),
             ("y='False'", [{'y': 'False'}]),
             ("c='FALSE'", [{'c': 'FALSE'}]),

--- a/orquesta/tests/unit/utils/test_parameters.py
+++ b/orquesta/tests/unit/utils/test_parameters.py
@@ -96,6 +96,23 @@ class InlineParametersTest(unittest.TestCase):
         for s, d in tests:
             self.assertListEqual(params.parse_inline_params(s), d)
 
+    def test_parse_string_in_quotes_input(self):
+        tests = [
+            ('x="true"', [{'x': "true"}]),
+            ('y="True"', [{'y': "True"}]),
+            ('c="TRUE"', [{'c': "TRUE"}]),
+            ('d="123"', [{'d': '123'}]),
+            ('e="abcde"', [{'e': 'abcde'}]),
+            ("x='false'", [{'x': 'false'}]),
+            ("y='False'", [{'y': 'False'}]),
+            ("c='FALSE'", [{'c': 'FALSE'}]),
+            ("d='123'", [{'d': '123'}]),
+            ("e='abcde'", [{'e': 'abcde'}]),
+        ]
+
+        for s, d in tests:
+            self.assertListEqual(params.parse_inline_params(s), d)
+
     def test_parse_other_types(self):
         self.assertListEqual(params.parse_inline_params(123), [])
         self.assertListEqual(params.parse_inline_params(True), [])

--- a/orquesta/tests/unit/utils/test_parameters.py
+++ b/orquesta/tests/unit/utils/test_parameters.py
@@ -83,6 +83,19 @@ class InlineParametersTest(unittest.TestCase):
     def test_parse_null_type(self):
         self.assertListEqual(params.parse_inline_params(None), [])
 
+    def test_parse_bool_input(self):
+        tests = [
+            ('x=true', [{'x': True}]),
+            ('y=True', [{'y': True}]),
+            ('c=TRUE', [{'c': True}]),
+            ('x=false', [{'x': False}]),
+            ('y=False', [{'y': False}]),
+            ('c=FALSE', [{'c': False}])
+        ]
+
+        for s, d in tests:
+            self.assertListEqual(params.parse_inline_params(s), d)
+
     def test_parse_other_types(self):
         self.assertListEqual(params.parse_inline_params(123), [])
         self.assertListEqual(params.parse_inline_params(True), [])

--- a/orquesta/utils/parameters.py
+++ b/orquesta/utils/parameters.py
@@ -53,6 +53,9 @@ def parse_inline_params(s, preserve_order=True):
         # Remove leading and trailing whitespaces.
         v = v.strip()
 
+        quotes_in_param = bool(re.findall(REGEX_VALUE_IN_QUOTES, v) or
+                               re.findall(REGEX_VALUE_IN_APOSTROPHES, v))
+
         # Remove leading and trailing double quotes.
         v = re.sub('^"', '', v)
         v = re.sub('"$', '', v)
@@ -61,12 +64,16 @@ def parse_inline_params(s, preserve_order=True):
         v = re.sub("^'", '', v)
         v = re.sub("'$", '', v)
 
-        if v.lower() == 'true' or v.lower() == 'false':
-            v = v.lower()
+        curly_brace_in_param = bool(v[0] == '{' and v[len(v) -1] == '}')
+        quotes_in_string = bool(quotes_in_param and not curly_brace_in_param)
+        is_bool_value = bool(v.lower() == 'true' or v.lower() == 'false')
 
         # Load string into dictionary.
         try:
-            v = json.loads(v)
+            if not quotes_in_string:
+                if is_bool_value:
+                    v = v.lower()
+                v = json.loads(v)
         except Exception:
             pass
 

--- a/orquesta/utils/parameters.py
+++ b/orquesta/utils/parameters.py
@@ -67,9 +67,9 @@ def parse_inline_params(s, preserve_order=True):
         quotes_in_string = False
         if v != "":
             # Check if param is a JSON string becuse it can be handled by json.loads()
-            curly_brace_in_param = bool(v[0] == '{' and v[-1] == '}')
-            quotes_in_string = bool(quotes_in_param and not curly_brace_in_param)
-        is_bool_value = bool(v.lower() == 'true' or v.lower() == 'false')
+            curly_brace_in_param = v[0] == '{' and v[-1] == '}'
+            quotes_in_string = quotes_in_param and not curly_brace_in_param
+        is_bool_value = v.lower() == 'true' or v.lower() == 'false'
 
         # Load string into dictionary.
         try:

--- a/orquesta/utils/parameters.py
+++ b/orquesta/utils/parameters.py
@@ -64,8 +64,11 @@ def parse_inline_params(s, preserve_order=True):
         v = re.sub("^'", '', v)
         v = re.sub("'$", '', v)
 
-        curly_brace_in_param = bool(v[0] == '{' and v[len(v) - 1] == '}')
-        quotes_in_string = bool(quotes_in_param and not curly_brace_in_param)
+        quotes_in_string = False
+        if v != "":
+            # Check if param is a JSON string becuse it can be handled by json.loads()
+            curly_brace_in_param = bool(v[0] == '{' and v[-1] == '}')
+            quotes_in_string = bool(quotes_in_param and not curly_brace_in_param)
         is_bool_value = bool(v.lower() == 'true' or v.lower() == 'false')
 
         # Load string into dictionary.

--- a/orquesta/utils/parameters.py
+++ b/orquesta/utils/parameters.py
@@ -64,7 +64,7 @@ def parse_inline_params(s, preserve_order=True):
         v = re.sub("^'", '', v)
         v = re.sub("'$", '', v)
 
-        curly_brace_in_param = bool(v[0] == '{' and v[len(v) -1] == '}')
+        curly_brace_in_param = bool(v[0] == '{' and v[len(v) - 1] == '}')
         quotes_in_string = bool(quotes_in_param and not curly_brace_in_param)
         is_bool_value = bool(v.lower() == 'true' or v.lower() == 'false')
 


### PR DESCRIPTION
Fixes https://github.com/StackStorm/orquesta/issues/130

During `parse_inline_params` is called to parse parameters input, the leading and trailing single/double quotes is removed. Digit and True/False in quotes will be parsed as number and boolean type instead of String after `json.loads()`.

Solution:
For string in quotes (not includes dictionary  `'x=\'{\"a\": 1}\''`), 'json.loads' is not called.