### PR TITLE
Added documentation about the dynamic execution pattern

### DIFF
--- a/docs/source/context.rst
+++ b/docs/source/context.rst
@@ -158,3 +158,56 @@ Since branch 1 will complete first, ``x=123`` will be written to the context dic
       task4:
         join: all
         action: core.noop
+
+Dynamic Action Execution
+------------------------
+
+Sometimes the name of the action to execute is not known when writing a workflow. Instead,
+the name of the action needs to be determined dynamically at runtime. This is possible with
+Orquesta by placing an expression in the ``action`` property of a ``task``. The expression
+for the ``action`` property will be rendered first, then the action will be executed given
+the other properties of the task. Example:
+
+.. code-block:: yaml
+    version: 1.0
+
+    input:
+      - dynamic_action
+      - data
+
+    tasks:
+      task1:
+        action: "{{ ctx().dynamic_action }}"
+        input:
+          x: "{{ ctx().data }}"
+
+In the example above, the workflow takes a parameter ``dynamic_action``, this is a string of
+the full action ref (``<pack>.<action>``, ex: ``core.local``) to execute.
+
+Additionally, action inputs can be dynamically assigned using expresssions:
+
+.. code-block:: yaml
+    version: 1.0
+
+    input:
+      - dynamic_action
+      - dynamic_input
+
+    tasks:
+      task1:
+        action: "{{ ctx().dynamic_action }}"
+        input: "{{ ctx().dynamic_input }}"
+
+In the example above, the workflow adds a parameter ``dynamic_input`` of type ``object``.
+The ``dynamic_input`` is then assigned directly to the tasks's ``input``, allowing any
+combination of parameters to be passed to the dynamic action. One might invoke this workflow
+using the following:
+
+.. code-block:: sh
+    st2 run default.dynamic_workflow dynamic_action='core.local' dynamic_input='{"cmd": "date"}'
+
+This is effectively the same as executing:
+
+.. code-block:: sh
+    st2 run core.local cmd=date
+

--- a/docs/source/context.rst
+++ b/docs/source/context.rst
@@ -169,6 +169,7 @@ for the ``action`` property will be rendered first, then the action will be exec
 the other properties of the task. Example:
 
 .. code-block:: yaml
+
     version: 1.0
 
     input:
@@ -187,6 +188,7 @@ the full action ref (``<pack>.<action>``, ex: ``core.local``) to execute.
 Additionally, action inputs can be dynamically assigned using expresssions:
 
 .. code-block:: yaml
+
     version: 1.0
 
     input:
@@ -204,10 +206,12 @@ combination of parameters to be passed to the dynamic action. One might invoke t
 using the following:
 
 .. code-block:: sh
+
     st2 run default.dynamic_workflow dynamic_action='core.local' dynamic_input='{"cmd": "date"}'
 
 This is effectively the same as executing:
 
 .. code-block:: sh
+
     st2 run core.local cmd=date
 

--- a/docs/source/expressions.rst
+++ b/docs/source/expressions.rst
@@ -1,9 +1,9 @@
 Expressions
 ===========
 
-Expressions can be employed almost anywhere in the workflow definition, from assigning value to
-action input, to evaluating criteria in the task transition, and data transformation when publishing
-variables.
+Expressions can be employed almost anywhere in the workflow definition, from the action name,
+to assigning value to action input, to evaluating criteria in the task transition,
+and data transformation when publishing variables.
 
 Here are some of the things that an expression can accomplish:
 
@@ -16,6 +16,7 @@ Here are some of the things that an expression can accomplish:
 
 Applied to workflows, here are some use cases:
 
+* Define what action to execute.
 * Define input values to action execution.
 * Define criteria for task transition.
 * Publish variables to the runtime context on task completion.


### PR DESCRIPTION
Orquesta provides the ability to use expressions in action names and input values. This power can be extremely useful in certain workflow development scenarios, so much so that i believe it deserves its own tern which i'm calling the "dynamic execution pattern".

This pattern, as described in this PR, is taking the feature of expression in action names, describes how it works and wraps it up with a few examples.