### PR TITLE
Fix overwritten context variables on task join

### DIFF
--- a/orquesta/specs/mistral/v2/tasks.py
+++ b/orquesta/specs/mistral/v2/tasks.py
@@ -162,7 +162,7 @@ class TaskSpec(base.Spec):
         errors = []
 
         if not re.match(expected_criteria_pattern, criteria[0]):
-            return in_ctx, errors
+            return in_ctx, new_ctx, errors
 
         task_publish_spec = getattr(self, 'publish') or {}
 
@@ -180,7 +180,7 @@ class TaskSpec(base.Spec):
             if key.startswith('__'):
                 out_ctx.pop(key)
 
-        return out_ctx, errors
+        return out_ctx, new_ctx, errors
 
 
 class TaskMappingSpec(base.MappingSpec):

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -242,7 +242,7 @@ class TaskSpec(base.Spec):
             if key.startswith('__'):
                 out_ctx.pop(key)
 
-        return out_ctx, errors
+        return out_ctx, new_ctx, errors
 
 
 class TaskMappingSpec(base.MappingSpec):

--- a/orquesta/tests/fixtures/workflows/native/join-context.yaml
+++ b/orquesta/tests/fixtures/workflows/native/join-context.yaml
@@ -1,0 +1,80 @@
+version: 1.0
+  
+description: A basic workflow to test merging of context on join.
+
+vars:
+  - msg1: foobar
+  - msg2: fubar
+
+tasks:
+  task1:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task2, task4, task6, task8
+
+  # branch 1
+  task2:
+    action: core.echo message="Fee fi"
+    next:
+      - when: <% succeeded() %>
+        publish: msg1=<% result() %>
+        do: task3
+  task3:
+    action: core.echo message="fo fum"
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - msg1: <% ctx().msg1 %> <% result() %>
+        do: task10
+
+  # branch 2
+  task4:
+    action: core.echo message="I smell the blood of an English man"
+    next:
+      - when: <% succeeded() %>
+        publish: msg2=<% result() %>
+        do: task5
+  task5:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task10
+
+  # branch 3
+  task6:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task7
+  task7:
+    action: core.echo message="Be alive, or be he dead"
+    next:
+      - when: <% succeeded() %>
+        publish: msg3=<% result() %>
+        do: task10
+
+  # branch 4
+  task8:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task9
+  task9:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        publish: msg4="I'll grind his bones to make my bread"
+        do: task10
+
+  # converge branches
+  task10:
+    join: all
+    action: core.noop
+
+output:
+  - messages:
+     - <% ctx().msg1 %>
+     - <% ctx().msg2 %>
+     - <% ctx().msg3 %>
+     - <% ctx().msg4 %>

--- a/orquesta/tests/unit/base.py
+++ b/orquesta/tests/unit/base.py
@@ -223,7 +223,9 @@ class WorkflowConductorTest(WorkflowComposerTest):
 
     def assert_conducting_sequences(self, wf_name, expected_task_seq, expected_routes=None,
                                     inputs=None, mock_states=None, mock_results=None,
-                                    expected_workflow_state=None, expected_output=None):
+                                    expected_workflow_state=None, expected_output=None,
+                                    expected_term_tasks=None):
+
         if not expected_routes:
             expected_routes = [[]]
 
@@ -307,6 +309,16 @@ class WorkflowConductorTest(WorkflowComposerTest):
 
         if expected_output is not None:
             self.assertDictEqual(conductor.get_workflow_output(), expected_output)
+
+        if expected_term_tasks:
+            expected_term_tasks = [
+                (task, 0) if not isinstance(task, tuple) else task
+                for task in expected_term_tasks
+            ]
+
+            term_tasks = conductor.flow.get_terminal_tasks()
+            actual_term_tasks = [(task['id'], task['route']) for task in term_tasks]
+            self.assertListEqual(actual_term_tasks, expected_term_tasks)
 
     def assert_workflow_state(self, wf_name, mock_flow, expected_wf_states, conductor=None):
         if not conductor:

--- a/orquesta/tests/unit/conducting/native/test_workflow_join.py
+++ b/orquesta/tests/unit/conducting/native/test_workflow_join.py
@@ -155,3 +155,50 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             expected_task_seq,
             mock_states=mock_states
         )
+
+    def test_join_context(self):
+        wf_name = 'join-context'
+
+        expected_output = {
+            'messages': [
+                'Fee fi fo fum',
+                'I smell the blood of an English man',
+                'Be alive, or be he dead',
+                "I'll grind his bones to make my bread"
+            ]
+        }
+
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task4',
+            'task6',
+            'task8',
+            'task3',
+            'task5',
+            'task7',
+            'task9',
+            'task10'
+        ]
+
+        mock_results = [
+            None,                                   # task1
+            'Fee fi',                               # task2
+            'I smell the blood of an English man',  # task4
+            None,                                   # task6
+            None,                                   # task8
+            'fo fum',                               # task3
+            None,                                   # task5
+            'Be alive, or be he dead',              # task7
+            None,                                   # task9
+            None                                    # task10
+        ]
+
+        self.assert_spec_inspection(wf_name)
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_results=mock_results,
+            expected_output=expected_output
+        )

--- a/orquesta/tests/unit/conducting/native/test_workflow_split.py
+++ b/orquesta/tests/unit/conducting/native/test_workflow_split.py
@@ -39,9 +39,19 @@ class SplitWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             ('task7', 2)
         ]
 
+        expected_term_tasks = [
+            ('task7', 1),
+            ('task7', 2)
+        ]
+
         self.assert_spec_inspection(wf_name)
 
-        self.assert_conducting_sequences(wf_name, expected_task_seq, expected_routes)
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            expected_routes=expected_routes,
+            expected_term_tasks=expected_term_tasks
+        )
 
     def test_splits(self):
         wf_name = 'splits'
@@ -72,9 +82,20 @@ class SplitWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             ('task8', 5)
         ]
 
+        expected_term_tasks = [
+            ('task8', 1),
+            ('task8', 4),
+            ('task8', 5)
+        ]
+
         self.assert_spec_inspection(wf_name)
 
-        self.assert_conducting_sequences(wf_name, expected_task_seq, expected_routes)
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            expected_routes=expected_routes,
+            expected_term_tasks=expected_term_tasks
+        )
 
     def test_nested_splits(self):
         wf_name = 'splits-nested'
@@ -117,9 +138,21 @@ class SplitWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             ('task10', 6)
         ]
 
+        expected_term_tasks = [
+            ('task10', 3),
+            ('task10', 4),
+            ('task10', 5),
+            ('task10', 6)
+        ]
+
         self.assert_spec_inspection(wf_name)
 
-        self.assert_conducting_sequences(wf_name, expected_task_seq, expected_routes)
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            expected_routes=expected_routes,
+            expected_term_tasks=expected_term_tasks
+        )
 
     def test_splits_mixed(self):
         wf_name = 'splits-mixed'
@@ -143,9 +176,19 @@ class SplitWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             ('task5', 4)
         ]
 
+        expected_term_tasks = [
+            ('task5', 3),
+            ('task5', 4)
+        ]
+
         self.assert_spec_inspection(wf_name)
 
-        self.assert_conducting_sequences(wf_name, expected_task_seq, expected_routes)
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            expected_routes=expected_routes,
+            expected_term_tasks=expected_term_tasks
+        )
 
     def test_splits_mixed_alt_branch(self):
         wf_name = 'splits-mixed'
@@ -180,13 +223,19 @@ class SplitWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             states.SUCCEEDED    # task5, 4
         ]
 
+        expected_term_tasks = [
+            ('task5', 3),
+            ('task5', 4)
+        ]
+
         self.assert_spec_inspection(wf_name)
 
         self.assert_conducting_sequences(
             wf_name,
             expected_task_seq,
-            expected_routes,
-            mock_states=mock_states
+            mock_states=mock_states,
+            expected_routes=expected_routes,
+            expected_term_tasks=expected_term_tasks
         )
 
     def test_splits_multiple_transition(self):
@@ -225,9 +274,21 @@ class SplitWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             ('task7', 6)
         ]
 
+        expected_term_tasks = [
+            ('task7', 3),
+            ('task7', 4),
+            ('task7', 5),
+            ('task7', 6)
+        ]
+
         self.assert_spec_inspection(wf_name)
 
-        self.assert_conducting_sequences(wf_name, expected_task_seq, expected_routes)
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            expected_routes=expected_routes,
+            expected_term_tasks=expected_term_tasks
+        )
 
     def test_very_many_splits(self):
         wf_name = 'splits-very-many'
@@ -262,9 +323,19 @@ class SplitWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             ('notify', 8)
         ]
 
+        expected_term_tasks = [
+            ('notify', 1),
+            ('notify', 8)
+        ]
+
         self.assert_spec_inspection(wf_name)
 
-        self.assert_conducting_sequences(wf_name, expected_task_seq, expected_routes)
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            expected_routes=expected_routes,
+            expected_term_tasks=expected_term_tasks
+        )
 
     def test_very_many_splits_alt(self):
         wf_name = 'splits-very-many'
@@ -343,6 +414,11 @@ class SplitWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             ('notify', 9)
         ]
 
+        expected_term_tasks = [
+            ('notify', 1),
+            ('notify', 9)
+        ]
+
         self.assert_spec_inspection(wf_name)
 
         self.assert_conducting_sequences(
@@ -350,5 +426,6 @@ class SplitWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             expected_task_seq,
             inputs=inputs,
             mock_results=mock_results,
-            expected_routes=expected_routes
+            expected_routes=expected_routes,
+            expected_term_tasks=expected_term_tasks
         )

--- a/orquesta/tests/unit/conducting/native/test_workflow_task_transition.py
+++ b/orquesta/tests/unit/conducting/native/test_workflow_task_transition.py
@@ -32,10 +32,15 @@ class TaskTransitionWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             states.SUCCEEDED    # task2
         ]
 
+        expected_term_tasks = [
+            'task2'
+        ]
+
         self.assert_conducting_sequences(
             wf_name,
             expected_task_seq,
-            mock_states=mock_states
+            mock_states=mock_states,
+            expected_term_tasks=expected_term_tasks
         )
 
         # Mock task1 error
@@ -49,10 +54,15 @@ class TaskTransitionWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             states.SUCCEEDED    # task3
         ]
 
+        expected_term_tasks = [
+            'task3'
+        ]
+
         self.assert_conducting_sequences(
             wf_name,
             expected_task_seq,
-            mock_states=mock_states
+            mock_states=mock_states,
+            expected_term_tasks=expected_term_tasks
         )
 
     def test_on_complete(self):
@@ -67,6 +77,11 @@ class TaskTransitionWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             'task4'
         ]
 
+        expected_term_tasks = [
+            'task2',
+            'task4'
+        ]
+
         mock_states = [
             states.SUCCEEDED,   # task1
             states.SUCCEEDED,   # task2
@@ -76,7 +91,8 @@ class TaskTransitionWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
         self.assert_conducting_sequences(
             wf_name,
             expected_task_seq,
-            mock_states=mock_states
+            mock_states=mock_states,
+            expected_term_tasks=expected_term_tasks
         )
 
         # Mock task1 error
@@ -92,10 +108,16 @@ class TaskTransitionWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             states.SUCCEEDED    # task4
         ]
 
+        expected_term_tasks = [
+            'task3',
+            'task4'
+        ]
+
         self.assert_conducting_sequences(
             wf_name,
             expected_task_seq,
-            mock_states=mock_states
+            mock_states=mock_states,
+            expected_term_tasks=expected_term_tasks
         )
 
     def test_task_transitions_split(self):
@@ -122,11 +144,17 @@ class TaskTransitionWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             states.SUCCEEDED    # task2, 2 on success
         ]
 
+        expected_term_tasks = [
+            ('task2', 1),
+            ('task2', 2)
+        ]
+
         self.assert_conducting_sequences(
             wf_name,
             expected_task_seq,
+            mock_states=mock_states,
             expected_routes=expected_routes,
-            mock_states=mock_states
+            expected_term_tasks=expected_term_tasks
         )
 
         # Mock task1 error
@@ -148,9 +176,15 @@ class TaskTransitionWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             states.SUCCEEDED    # task2, 2 on failure
         ]
 
+        expected_term_tasks = [
+            ('task2', 1),
+            ('task2', 2)
+        ]
+
         self.assert_conducting_sequences(
             wf_name,
             expected_task_seq,
+            mock_states=mock_states,
             expected_routes=expected_routes,
-            mock_states=mock_states
+            expected_term_tasks=expected_term_tasks
         )

--- a/orquesta/tests/unit/conducting/test_task_flow.py
+++ b/orquesta/tests/unit/conducting/test_task_flow.py
@@ -88,7 +88,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
 
         task_route = 0
         task_name = 'task1'
-        conductor.add_task_flow(task_name, task_route, in_ctx_idx=0)
+        conductor.add_task_flow(task_name, task_route)
 
         expected_task_flow_idx = 0
         actual_task_flow_idx = conductor._get_task_flow_idx(task_name, task_route)
@@ -97,7 +97,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'next': {},
             'prev': {}
         }
@@ -119,7 +119,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': None,
+            'ctxs': {'in': [0]},
             'next': {},
             'prev': {}
         }
@@ -141,7 +141,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'state': 'running',
             'next': {},
             'prev': {}
@@ -155,7 +155,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'state': 'succeeded',
             'next': {
                 'task2__t0': True,
@@ -181,7 +181,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'state': 'running',
             'next': {},
             'prev': {}
@@ -200,13 +200,14 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'state': 'failed',
             'next': {
                 'task2__t0': False,
                 'task5__t0': False
             },
-            'prev': {}
+            'prev': {},
+            'term': True
         }
 
         actual_task_flow_entry = conductor.get_task_flow_entry(task_name, task_route)
@@ -270,7 +271,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'state': 'requested',
             'next': {},
             'prev': {}
@@ -286,7 +287,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'state': 'requested',
             'next': {},
             'prev': {}
@@ -310,7 +311,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'state': 'running',
             'next': {},
             'prev': {}
@@ -324,7 +325,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'state': 'succeeded',
             'next': {
                 'task2__t0': True,
@@ -350,7 +351,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'state': 'running',
             'next': {},
             'prev': {
@@ -366,7 +367,7 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
         expected_task_flow_entry = {
             'id': task_name,
             'route': task_route,
-            'ctx': 0,
+            'ctxs': {'in': [0]},
             'state': 'succeeded',
             'next': {
                 'task3__t0': True
@@ -410,7 +411,9 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
             {
                 'id': 'task1',
                 'route': task_route,
-                'ctx': 0,
+                'ctxs': {
+                    'in': [0]
+                },
                 'state': 'succeeded',
                 'next': {
                     'task2__t0': True,
@@ -421,7 +424,9 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
             {
                 'id': 'task2',
                 'route': task_route,
-                'ctx': 0,
+                'ctxs': {
+                    'in': [0]
+                },
                 'state': 'succeeded',
                 'next': {
                     'task3__t0': True
@@ -433,7 +438,9 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
             {
                 'id': 'task3',
                 'route': task_route,
-                'ctx': 0,
+                'ctxs': {
+                    'in': [0]
+                },
                 'state': 'succeeded',
                 'next': {
                     'task4__t0': True
@@ -445,7 +452,9 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
             {
                 'id': 'task4',
                 'route': task_route,
-                'ctx': 0,
+                'ctxs': {
+                    'in': [0]
+                },
                 'state': 'succeeded',
                 'next': {
                     'task2__t0': True
@@ -457,7 +466,9 @@ class WorkflowConductorTaskFlowTest(base.WorkflowConductorTest):
             {
                 'id': 'task2',
                 'route': task_route,
-                'ctx': 0,
+                'ctxs': {
+                    'in': [0]
+                },
                 'state': 'running',
                 'next': {},
                 'prev': {


### PR DESCRIPTION
Refactor the internal data structure for storing task context. Previously, if there is change in context at task transition after publish, an entire copy of the context is stored. So when a task join happens and one branch modifies one variable and another branch modifies another variable, the last branch that merges the context for the join task will overwrite the variables for the other branch. With this change, only diff in the context is stored after each task transition and the join task will merge the diffs chronologically. This will also reduce the memory footprint used by the internal data structure because only diffs are stored. Fixes #112