### PR TITLE
Restrict ctx function from returning internal vars

### DIFF
--- a/orquesta/exceptions.py
+++ b/orquesta/exceptions.py
@@ -34,6 +34,12 @@ class VariableUndefinedError(Exception):
         Exception.__init__(self, 'The variable "%s" is undefined.' % var)
 
 
+class VariableInaccessibleError(Exception):
+
+    def __init__(self, var):
+        Exception.__init__(self, 'The variable "%s" is for internal use and inaccessible.' % var)
+
+
 class SchemaDefinitionError(Exception):
     pass
 

--- a/orquesta/expressions/functions/common.py
+++ b/orquesta/expressions/functions/common.py
@@ -38,7 +38,13 @@ def zip_(*args, **kwargs):
 
 
 def ctx_(context, key=None):
-    if key and key not in context['__vars']:
-        raise exc.VariableUndefinedError(key)
+    if key:
+        if key not in context['__vars']:
+            raise exc.VariableUndefinedError(key)
 
-    return context['__vars'][key] if key else context['__vars']
+        if key in context['__vars'] and key.startswith('__'):
+            raise exc.VariableInaccessibleError(key)
+
+        return context['__vars'][key]
+    else:
+        return {k: v for k, v in six.iteritems(context['__vars']) if not k.startswith('__')}

--- a/orquesta/specs/base.py
+++ b/orquesta/specs/base.py
@@ -442,11 +442,11 @@ class Spec(object):
                 'schema_path': schema_path
             }
 
-        def decorate_ctx_var_error(var):
+        def decorate_ctx_var_error(var, msg):
             error = expr_util.format_error(
                 var['type'],
                 var['expression'],
-                'Variable "%s" is referenced before assignment.' % var['name'],
+                msg,
                 var['spec_path'],
                 var['schema_path']
             )
@@ -478,8 +478,16 @@ class Spec(object):
                 ctx_vars.append(decorate_ctx_var(var, spec_path, schema_path))
 
             for ctx_var in ctx_vars:
+                if ctx_var['name'].startswith('__'):
+                    err_msg = (
+                        'Variable "%s" that is prefixed with double underscores is considered '
+                        'a private variable and cannot be referenced.' % ctx_var['name']
+                    )
+                    errors.append(decorate_ctx_var_error(ctx_var, err_msg))
+
                 if ctx_var['name'] not in rolling_ctx:
-                    errors.append(decorate_ctx_var_error(ctx_var))
+                    err_msg = 'Variable "%s" is referenced before assignment.' % ctx_var['name']
+                    errors.append(decorate_ctx_var_error(ctx_var, err_msg))
 
             if prop_name in self._context_inputs:
                 updated_ctx = get_ctx_inputs(prop_name, prop_value)


### PR DESCRIPTION
The workflow execution context contains internal variables prefixed with double underscores that contain state information. Spec inspection is refactored to prevent references of variables prefixed with double underscores when using the ctx function. The ctx function is refactored to not return any variables prefixed with double underscores.