### PR TITLE
Fix task transition error on completing task in pending status

### DIFF
--- a/orquesta/machines.py
+++ b/orquesta/machines.py
@@ -146,6 +146,7 @@ WORKFLOW_STATE_MACHINE_DATA = {
         events.WORKFLOW_RESUMING_WORKFLOW_COMPLETED: statuses.SUCCEEDED,
         events.WORKFLOW_CANCELING_WORKFLOW_DORMANT: statuses.CANCELED,
         events.WORKFLOW_CANCELED_WORKFLOW_DORMANT: statuses.CANCELED,
+        events.WORKFLOW_FAILED: statuses.FAILED,
         events.TASK_RUNNING: statuses.RUNNING,
         events.TASK_RESUMING: statuses.RUNNING
     },


### PR DESCRIPTION
A workflow goes into paused status when a task goes into pending status. If the task transition has error, the workflow does not go into failed status when the task is completed. This patch add an entry in the state machine for workflow to go from paused to failed status.