### PR TITLE
Allow tasks in the same transition with fail to run

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.6
+---
+
+Fixed
+~~~~~
+
+* Allow tasks in the same transition with a "fail" command to run. (bug fix)
+
 0.5
 ---
 

--- a/orquesta/tests/fixtures/workflows/native/error-log-fail-concurrent.yaml
+++ b/orquesta/tests/fixtures/workflows/native/error-log-fail-concurrent.yaml
@@ -11,5 +11,3 @@ tasks:
         do: log, fail
   log:
     action: core.echo message=<% ctx().error %>
-    next:
-      - when: <% succeeded() %>

--- a/orquesta/tests/unit/base.py
+++ b/orquesta/tests/unit/base.py
@@ -256,14 +256,14 @@ class WorkflowConductorTest(WorkflowComposerTest):
             run_q.put(task)
 
         # Serialize workflow conductor to mock async execution.
-        wf_conducting_status = conductor.serialize()
+        wf_conducting_state = conductor.serialize()
 
-        # Process until workflow reaches a completed status.
-        while conductor.get_workflow_status() not in statuses.COMPLETED_STATUSES:
+        # Process until there are not more tasks in queue.
+        while not run_q.empty():
             # Deserialize workflow conductor to mock async execution.
-            conductor = conducting.WorkflowConductor.deserialize(wf_conducting_status)
+            conductor = conducting.WorkflowConductor.deserialize(wf_conducting_state)
 
-            # Clear the run queue and move all the tasks to running.
+            # Process all the tasks in the run queue.
             while not run_q.empty():
                 current_task = run_q.get()
                 current_task_id = current_task['id']
@@ -285,11 +285,7 @@ class WorkflowConductorTest(WorkflowComposerTest):
                 run_q.put(next_task)
 
             # Serialize workflow execution graph to mock async execution.
-            wf_conducting_status = conductor.serialize()
-
-            # Exit if run queue is empty.
-            if run_q.empty():
-                break
+            wf_conducting_state = conductor.serialize()
 
         actual_task_seq = [
             (entry['id'], entry['route'])

--- a/orquesta/tests/unit/conducting/native/test_workflow_error_handling.py
+++ b/orquesta/tests/unit/conducting/native/test_workflow_error_handling.py
@@ -52,7 +52,8 @@ class WorkflowErrorHandlingConductorTest(base.OrchestraWorkflowConductorTest):
 
         expected_task_seq = [
             'task1',
-            'fail'
+            'fail',
+            'log'
         ]
 
         mock_statuses = [


### PR DESCRIPTION
Allow tasks in the same transition with a "fail" command to be staged. These tasks will be returned when get_next_tasks is called even when the workflow execution has failed. Closes #113 