### PR TITLE
Fix Jinja evaluator to evaluate block expression correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Fixed
 ~~~~~
 
 * Allow tasks in the same transition with a "fail" command to run. (bug fix)
+* Fix Jinja block expression to render correctly. (bug fix)
 
 0.5
 ---

--- a/orquesta/tests/unit/expressions/test_jinja_eval_raw_blocks.py
+++ b/orquesta/tests/unit/expressions/test_jinja_eval_raw_blocks.py
@@ -43,6 +43,20 @@ class JinjaEvaluationTest(test_base.ExpressionEvaluatorTest):
 
         self.assertEqual('abc', self.evaluator.evaluate(expr, data))
 
+    def test_block_eval_complex_data(self):
+        expr = '{% for i in ctx().x %}{{ i.k }}{{ ctx().z }}{% endfor %}'
+
+        data = {
+            'x': [
+                {'k': 'a'},
+                {'k': 'b'},
+                {'k': 'c'}
+            ],
+            'z': '->'
+        }
+
+        self.assertEqual('a->b->c->', self.evaluator.evaluate(expr, data))
+
     def test_block_eval_undefined(self):
         expr = '{% for i in ctx().x %}{{ ctx().y }}{% endfor %}'
 


### PR DESCRIPTION
If there is a for loop in the Jinja block expression and the item is a complex data type, the current Jinja evaluator converted the item into string type. So if the item is a dictionary, and user tries to access some key value pair, the Jinja evaluator returns an error saying the item is undefined. The Jinja evaluator tries to evaluate individual expression first, even for expression within the for loop, before evaluating the block expression which resulted in the undefined error when the item of the for loop is referenced. To fix, the text is checked to see if there is a Jinja block expression. If there is a Jinja block expression, the entire text is rendered together. Otherwise, if there is no Jinja block expression, then standalone expressions will be rendered individually to preserve type. The method to render Jinja block expression returns string type only. Fixes https://github.com/StackStorm/st2/issues/4701.