### PR TITLE
Rephrased error message for unreachable join task

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 0.6
 ---
 
+Changed
+~~~~~~~
+
+* Rephrased the error message for the unreachable join task. Fixes #162 (improvement)
+
 Fixed
 ~~~~~
 

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -465,8 +465,15 @@ class TaskMappingSpec(native_v1_specs.MappingSpec):
                 meta['reachable'] = (meta['splits'] == staging[prev_task_name]['splits'])
 
                 if not meta['reachable']:
+                    msg = (
+                        'The join task "%s" is unreachable. A join task is determined to be '
+                        'unreachable if there are nested forks from multi-referenced tasks '
+                        'that join on the said task. This is ambiguous to the workflow engine '
+                        'because it does not know at which level should the join occurs.'
+                    )
+
                     entry = {
-                        'message': 'The join task "%s" is unreachable.' % task_name,
+                        'message': msg % task_name,
                         'spec_path': meta['spec_path'],
                         'schema_path': meta['schema_path']
                     }

--- a/orquesta/tests/unit/specs/native/test_workflow_spec_validate.py
+++ b/orquesta/tests/unit/specs/native/test_workflow_spec_validate.py
@@ -412,7 +412,12 @@ class WorkflowSpecValidationTest(test_base.OrchestraWorkflowSpecTest):
         expected_errors = {
             'semantics': [
                 {
-                    'message': 'The join task "task5" is unreachable.',
+                    'message': (
+                        'The join task "task5" is unreachable. A join task is determined to be '
+                        'unreachable if there are nested forks from multi-referenced tasks '
+                        'that join on the said task. This is ambiguous to the workflow engine '
+                        'because it does not know at which level should the join occurs.'
+                    ),
                     'spec_path': 'tasks.task5',
                     'schema_path': 'properties.tasks.patternProperties.^\\w+$'
                 }


### PR DESCRIPTION
Rephrased the error message for unreachable join task to be more descriptive and clearer to the user why the join task is unreachable. Fixes #162.