### PR TITLE
Fix conducting of cycle with a fork

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+In development
+--------------
+
+Fixed
+-----
+
+* Fix conducting of cycle with a fork. Fixes #169 (bug fix)
+
 1.0.0
 -----
 

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -653,8 +653,12 @@ class WorkflowConductor(object):
         task_state_idx = self._get_task_state_idx(task_id, route)
 
         # If task is already completed and in cycle, then create new task state entry.
-        if (self.graph.in_cycle(task_id) and
-                task_state_entry.get('status') in statuses.COMPLETED_STATUSES):
+        # Unfortunately, the method in the graph to check for cycle is too simple and
+        # misses forks that extends from the cycle. The check here assumes that the
+        # last task entry is already completed and the new task status is one of the
+        # starting statuses, then there is high likelihood that this is a cycle.
+        if (task_state_entry.get('status') in statuses.COMPLETED_STATUSES and
+                event.status and event.status in statuses.STARTING_STATUSES):
             task_state_entry = self.add_task_state(
                 task_id,
                 staged_task['route'],

--- a/orquesta/tests/fixtures/workflows/native/cycle-fork.yaml
+++ b/orquesta/tests/fixtures/workflows/native/cycle-fork.yaml
@@ -1,0 +1,46 @@
+---
+version: '1.0'
+
+description: A sample workflow with a fork that stems from a cycle.
+
+vars:
+  - cheer: false
+  - work: false
+
+tasks:
+  # This init task is required to tell the workflow engine where to start.
+  # Otherwise with just a cycle, the workflow engine cannot tell where to start.
+  init:
+    action: core.noop
+    next:
+      - do: query
+
+  # This is the start of the cycle in the workflow.
+  query:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        publish: cheer=<% result() %> work=<% result() %>
+        do: decide_cheer, decide_work
+
+
+  # The branch under the decide_work task will cycle back to the query task.
+  decide_work:
+    next:
+      - when: <% ctx().work %>
+        do: notify_work, toil
+  notify_work:
+    action: core.noop
+  toil:
+    action: core.echo message="This is hard work."
+    next:
+      - do: query
+
+
+  # The branch under the decide_cheer task is a fork from the cycle.
+  decide_cheer:
+    next:
+      - when: <% ctx().cheer %>
+        do: cheer
+  cheer:
+    action: core.echo message="You can do it!"

--- a/orquesta/tests/unit/conducting/native/test_workflow_cycle.py
+++ b/orquesta/tests/unit/conducting/native/test_workflow_cycle.py
@@ -91,3 +91,36 @@ class CyclicWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
         self.assert_spec_inspection(wf_name)
 
         self.assert_conducting_sequences(wf_name, expected_task_seq, mock_statuses=mock_statuses)
+
+    def test_cycle_and_fork(self):
+        wf_name = 'cycle-fork'
+
+        expected_task_seq = [
+            'init',
+            'query',
+            'decide_cheer',
+            'decide_work',
+            'cheer',
+            'notify_work',
+            'toil',
+            'query',
+            'decide_cheer',
+            'decide_work'
+        ]
+
+        mock_results = [
+            None,   # init
+            True,   # query
+            None,   # decide_cheer
+            None,   # decide_work
+            None,   # cheer
+            None,   # notify_work
+            None,   # toil
+            False,  # query
+            None,   # decide_cheer
+            None,   # decide_work
+        ]
+
+        self.assert_spec_inspection(wf_name)
+
+        self.assert_conducting_sequences(wf_name, expected_task_seq, mock_results=mock_results)


### PR DESCRIPTION
If there is a branch that fork from a cycle in the workflow graph, during runtime and the workflow runs the cycle more than once, tasks under the forked branch will not execute a second time. The issue is caused by the networkx graph not recognizing the forked branch as part of the cycle. The conductor is changed to determine a task is executed more than once as part of the cycle when the last task entry is completed and the new task status is one of the starting execution statuses. Fixes #169