### PR TITLE
Trstruth/start task

### DIFF
--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -125,6 +125,7 @@ class TaskSpec(native_v1_specs.Spec):
         'type': 'object',
         'properties': {
             'delay': spec_types.STRING_OR_POSITIVE_INTEGER,
+            'start': spec_types.BOOLEAN,
             'join': {
                 'oneOf': [
                     {'enum': ['all']},
@@ -301,10 +302,20 @@ class TaskMappingSpec(native_v1_specs.MappingSpec):
         start_tasks = [
             (task_name, None, None)
             for task_name in self.keys()
-            if not self.get_prev_tasks(task_name)
+            if self.is_start_task(task_name)
         ]
 
         return sorted(start_tasks, key=lambda x: x[0])
+
+    def is_start_task(self, task_name):
+        task_spec = self.get_task(task_name)
+        if getattr(task_spec, 'start', False):
+            return True
+
+        if not self.get_prev_tasks(task_name):
+            return True
+
+        return False
 
     def is_join_task(self, task_name):
         task_spec = self.get_task(task_name)

--- a/orquesta/specs/types.py
+++ b/orquesta/specs/types.py
@@ -96,6 +96,10 @@ STRING_OR_BOOLEAN = {
     ]
 }
 
+BOOLEAN = {
+    "type": "boolean"
+}
+
 STRING_OR_ONE_KEY_DICT = {
     "oneOf": [
         NONEMPTY_STRING,

--- a/orquesta/tests/unit/specs/native/test_task_spec.py
+++ b/orquesta/tests/unit/specs/native/test_task_spec.py
@@ -622,7 +622,7 @@ class TaskSpecTest(test_base.OrchestraWorkflowSpecTest):
         wf_spec = self.instantiate(wf_def)
 
         self.assertDictEqual(wf_spec.inspect(), {})
-        
+
         # start_tasks() dict is empty because there are no tasks with
         # 0 inbound task transitions
         self.assertListEqual(wf_spec.tasks.get_start_tasks(), [])


### PR DESCRIPTION
Here, we propose an addition to the task spec which allows us to define a boolean `start` attr on a task definition.  Today, the workflow engine parses the workflow graph and finds tasks that have 0 task inbound transitions.  These tasks are implicitly designated as start tasks.  This feature allows a user to explicitly denote a task as a "starting task"

Consider the following:
```yaml
version: 1.0

description: A wrapper workflow

input:
  - task_name
  - args
  - kwargs
  - timeout
  - retries

tasks:
  start:
    action: core.noop
    next:
      - when: <% succeeded() %>
        do: execute_task

  execute_task:
    start: "false"
    action: pack.action_ref
    input:
      task_name: <% ctx(task_name) %>
      args: <% ctx(args) %>
      kwargs: <% ctx(kwargs) %>
      timeout: <% ctx(timeout) %>
    next:
      - publish:
          - task_result: <% result().result %>
      - when: <% failed() and ctx(retries) > 0  %>
        do: execute_task
        publish:
          - retries: <% ctx(retries) - 1 %>
      - when: <% failed() and ctx(retries) <= 0 %>
        do: wait

  wait:
    action: core.ask
    input:
      ttl: 0
      schema:
        type: object
        properties:
          retry:
            type: boolean
            description: "Check the box to retry the task, otherwise leave it unchecked to fail the task"
            required: True
    next:
      - when: <% succeeded() and result().response.retry %>
        do: execute_task
      - when: <% succeeded() and not result().response.retry %>
        do: fail

output:
  - task_result: <% ctx(task_result) %>
```
![image](https://user-images.githubusercontent.com/9982381/61832241-5be0e880-ae25-11e9-9c01-371e7a674f7f.png)

This is a variation on a workflow we use frequently in production.  It is designed to be called as a subworkflow, and provides some resilience against unexpected external service errors.  If `execute_task` fails for whatever reason, the workflow transitions to an inquiry called `wait` which allows the user to either fail the entire sub workflow, or retry the execution of the task.

Notice that the `start` task exists solely to satisfy the implicit resolution of start tasks; because `execute_task` has an inbound task transition, we need an "entrypoint" task to denote where the start of the workflow is.  This creates clutter in task executions and puts unnecessary load on our system.

This PR allows the user to explicitly define a `start` attribute on a task definition, and extends the functionality of the workflow engine to properly denote such tasks as start tasks.  The workflow definition then becomes

```yaml
version: 1.0

description: A wrapper workflow

input:
  - task_name
  - args
  - kwargs
  - timeout
  - retries

tasks:
  execute_task:
    start: true
    action: pack.action_ref
    input:
      task_name: <% ctx(task_name) %>
      args: <% ctx(args) %>
      kwargs: <% ctx(kwargs) %>
      timeout: <% ctx(timeout) %>
    next:
      - publish:
          - task_result: <% result().result %>
      - when: <% failed() and ctx(retries) > 0  %>
        do: execute_task
        publish:
          - retries: <% ctx(retries) - 1 %>
      - when: <% failed() and ctx(retries) <= 0 %>
        do: wait

  wait:
    action: core.ask
    input:
      ttl: 0
      schema:
        type: object
        properties:
          retry:
            type: boolean
            description: "Check the box to retry the task, otherwise leave it unchecked to fail the task"
            required: True
    next:
      - when: <% succeeded() and result().response.retry %>
        do: execute_task
      - when: <% succeeded() and not result().response.retry %>
        do: fail

output:
  - task_result: <% ctx(task_result) %>
```
![image](https://user-images.githubusercontent.com/9982381/61832349-acf0dc80-ae25-11e9-8326-89ba3f221845.png)
Note the absence of the `start` task, and the `start` attribute defined on `execute_task`

This feature will simplify our workflow definitions by removing auxiliary task definitions, while making the workflow definition more explicit, and comes at the cost of one (optional) attribute definition in the task spec.  Any feedback/discussion is appreciated.