### PR TITLE
 Fix request_workflow_status to ignore certain status change errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Fixed
 -----
 
 * Fix conducting of cycle with a fork. Fixes #169 (bug fix)
+* Fix request_workflow_status to ignore certain status change errors such as pausing a workflow
+  that is already pausing and canceling a workflow that is already canceling. (bug fix)
 
 1.0.0
 -----

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -358,7 +358,19 @@ class WorkflowConductor(object):
         # Get workflow status after event is processed.
         updated_status = self.get_workflow_status()
 
-        # If status has not changed as expected, then raise exception.
+        # Ignore if workflow hasn't changed from paused to pausing.
+        if (status == statuses.PAUSED and
+                current_status == statuses.PAUSING and
+                updated_status == statuses.PAUSING):
+            return
+
+        # Ignore if workflow hasn't changed from canceled to canceling.
+        if (status == statuses.CANCELED and
+                current_status == statuses.CANCELING and
+                updated_status == statuses.CANCELING):
+            return
+
+        # Otherwise, if status has not changed as expected, then raise exception.
         if status != current_status and current_status == updated_status:
             raise exc.InvalidWorkflowStatusTransition(current_status, wf_ex_event.name)
 

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_pause_and_resume.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_pause_and_resume.py
@@ -149,6 +149,10 @@ class WorkflowConductorPauseResumeTest(test_base.WorkflowConductorTest):
         self.forward_task_statuses(conductor, 'task1', [statuses.RUNNING])
         self.assertEqual(conductor.get_workflow_status(), statuses.RUNNING)
 
+        # Pause the workflow.
+        conductor.request_workflow_status(statuses.PAUSING)
+        self.assertEqual(conductor.get_workflow_status(), statuses.PAUSING)
+
         # Complete task1 and assert the workflow execution fails
         # due to the expression error in the task transition.
         self.forward_task_statuses(conductor, 'task1', [statuses.SUCCEEDED])


### PR DESCRIPTION
If a workflow is still pausing and pause is requested again, request_workflow_status will not be able to change the workflow status to paused. This is normal and exception should not be raised. This is a similar case for workflow cancelation.