### PR TITLE
Refactor conductor to not store each item result in task state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Changed
 * Replace "noop" with "continue" when "do" is not specified. The new "continue" command
   will not alter the previous task state and will continue to conduct the workflow
   execution. StackStorm/st2#4740 (improvement)
+* Refactor conductor to not store each item result in task state. If there are a lot of items
+  and/or result size is huge per item, then there will be a performance impact on database
+  write operations when recording the conductor state. (improvement)
 
 Fixed
 -----

--- a/orquesta/events.py
+++ b/orquesta/events.py
@@ -345,6 +345,14 @@ class ActionExecutionEvent(ExecutionEvent):
         )
 
 
+class TaskItemActionExecutionEvent(ActionExecutionEvent):
+
+    def __init__(self, item_id, status, result=None, accumulated_result=None):
+        super(TaskItemActionExecutionEvent, self).__init__(status, result=result)
+        self.item_id = item_id
+        self.accumulated_result = accumulated_result
+
+
 class EngineOperationEvent(ExecutionEvent):
     pass
 

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_with_items_cancel.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_with_items_cancel.py
@@ -220,8 +220,7 @@ class WorkflowConductorWithItemsCancelTest(test_base.WorkflowConductorWithItemsT
 
         # Set the items to running status.
         for i in range(0, len(task_ctx['xs'])):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -235,10 +234,10 @@ class WorkflowConductorWithItemsCancelTest(test_base.WorkflowConductorWithItemsT
 
         # Complete the items.
         for i in range(0, len(task_ctx['xs'])):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [statuses.SUCCEEDED]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert the task is completed and workflow is canceled.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -302,8 +301,7 @@ class WorkflowConductorWithItemsCancelTest(test_base.WorkflowConductorWithItemsT
 
         # Set the items to running status.
         for i in range(0, len(task_ctx['xs'])):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -317,10 +315,10 @@ class WorkflowConductorWithItemsCancelTest(test_base.WorkflowConductorWithItemsT
 
         # Complete the items.
         for i in range(0, len(task_ctx['xs'])):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [statuses.SUCCEEDED]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert the task is completed and workflow is canceled.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -537,8 +535,7 @@ class WorkflowConductorWithItemsCancelTest(test_base.WorkflowConductorWithItemsT
 
         # Set the items to running status.
         for i in range(0, concurrency):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -552,10 +549,10 @@ class WorkflowConductorWithItemsCancelTest(test_base.WorkflowConductorWithItemsT
 
         # Complete the items.
         for i in range(0, concurrency):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [statuses.SUCCEEDED]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert the task and workflow are canceled.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_with_items_pause_and_resume.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_with_items_pause_and_resume.py
@@ -244,8 +244,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
         self.assertEqual(conductor.get_workflow_status(), statuses.PAUSED)
 
         # Resume the paued action execution.
-        context = {'item_id': 1}
-        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [1])
 
         # Assert the task and workflow is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -259,9 +258,8 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
         self.assertEqual(conductor.get_workflow_status(), statuses.RUNNING)
 
         # Complete the resumed action execution.
-        context = {'item_id': 1}
         result = task_ctx['xs'][1]
-        self.forward_task_statuses(conductor, task_name, [statuses.SUCCEEDED], [context], [result])
+        self.forward_task_statuses(conductor, task_name, [statuses.SUCCEEDED], [1], [result])
 
         # Assert the task is removed from staging.
         self.assertIsNone(conductor.workflow_state.get_staged_task(task_name, task_route))
@@ -328,8 +326,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Set the items to running status.
         for i in range(0, len(task_ctx['xs'])):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -344,10 +341,10 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Complete the items.
         for i in range(0, len(task_ctx['xs'])):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [statuses.SUCCEEDED]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert the task and workflow are completed.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -415,8 +412,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Set the items to running status.
         for i in range(0, len(task_ctx['xs'])):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -431,10 +427,10 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Complete the items.
         for i in range(0, len(task_ctx['xs'])):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [statuses.SUCCEEDED]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert the task and workflow are completed.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -541,8 +537,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Set the items to running status.
         for i in range(0 + concurrency, len(task_ctx['xs'])):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -551,10 +546,10 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Complete the items.
         for i in range(0 + concurrency, len(task_ctx['xs'])):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [statuses.SUCCEEDED]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert the task and workflow are completed.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -657,8 +652,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Set the items to running status.
         for i in range(0 + concurrency, len(task_ctx['xs'])):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -667,10 +661,10 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Complete the items.
         for i in range(0 + concurrency, len(task_ctx['xs'])):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [statuses.SUCCEEDED]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert the task and workflow are completed.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -739,8 +733,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Set the items to running status.
         for i in range(0, concurrency):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -755,10 +748,10 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Complete the items.
         for i in range(0, concurrency):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [statuses.SUCCEEDED]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert the task and workflow are paused.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -786,8 +779,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Set the items to running status.
         for i in range(0 + concurrency, len(task_ctx['xs'])):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -796,10 +788,10 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Complete the items.
         for i in range(0 + concurrency, len(task_ctx['xs'])):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [statuses.SUCCEEDED]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert the task and workflow are completed.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -967,8 +959,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
         self.assertEqual(conductor.get_workflow_status(), statuses.PAUSED)
 
         # Resume the paued action execution.
-        context = {'item_id': 1}
-        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [1])
 
         # Assert the task and workflow is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -980,9 +971,8 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
         self.assertEqual(conductor.get_workflow_status(), statuses.RUNNING)
 
         # Complete the resumed action execution.
-        context = {'item_id': 1}
         result = task_ctx['xs'][1]
-        self.forward_task_statuses(conductor, task_name, [statuses.SUCCEEDED], [context], [result])
+        self.forward_task_statuses(conductor, task_name, [statuses.SUCCEEDED], [1], [result])
 
         # Assert the task is removed from staging.
         self.assertIsNone(conductor.workflow_state.get_staged_task(task_name, task_route))
@@ -1073,8 +1063,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
         self.assertEqual(conductor.get_workflow_status(), statuses.PAUSED)
 
         # Resume the paued action execution.
-        context = {'item_id': 1}
-        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [1])
 
         # Assert the task and workflow is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -1086,9 +1075,8 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
         self.assertEqual(conductor.get_workflow_status(), statuses.RUNNING)
 
         # Complete the resumed action execution.
-        context = {'item_id': 1}
         result = task_ctx['xs'][1]
-        self.forward_task_statuses(conductor, task_name, [statuses.SUCCEEDED], [context], [result])
+        self.forward_task_statuses(conductor, task_name, [statuses.SUCCEEDED], [1], [result])
 
         # Assert the task is removed from staging.
         self.assertIsNotNone(conductor.workflow_state.get_staged_task(task_name, task_route))

--- a/orquesta/tests/unit/states/native/test_workflow_with_items.py
+++ b/orquesta/tests/unit/states/native/test_workflow_with_items.py
@@ -64,18 +64,17 @@ class WorkflowConductorWithItemsTest(test_base.WorkflowConductorWithItemsTest):
         self.assert_task_list(conductor, actual_tasks, expected_tasks)
 
         # Set the item to running status.
-        context = {'item_id': 0}
-        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [0])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
         self.assertEqual(actual_task_status, statuses.RUNNING)
 
         # Change status for the item.
-        contexts = [{'item_id': 0}]
+        item_ids = [0]
         results = [task_ctx['xs'][0]]
         status_changes = [ac_ex_status]
-        self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+        self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert task and workflow status.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -151,8 +150,7 @@ class WorkflowConductorWithItemsTest(test_base.WorkflowConductorWithItemsTest):
 
         # Set the items to running status.
         for i in range(0, len(ac_ex_statuses)):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -160,18 +158,18 @@ class WorkflowConductorWithItemsTest(test_base.WorkflowConductorWithItemsTest):
 
         # Change status for all but one item.
         for i in range(0, len(ac_ex_statuses) - 1):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [ac_ex_statuses[i]]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
             actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
 
         # Change status for the last item.
         i = len(ac_ex_statuses) - 1
-        contexts = [{'item_id': i}]
+        item_ids = [i]
         results = [task_ctx['xs'][i]]
         status_changes = [ac_ex_statuses[i]]
-        self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+        self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert task and workflow status.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']

--- a/orquesta/tests/unit/states/native/test_workflow_with_items_cancel.py
+++ b/orquesta/tests/unit/states/native/test_workflow_with_items_cancel.py
@@ -64,8 +64,7 @@ class WorkflowConductorWithItemsCancelTest(test_base.WorkflowConductorWithItemsT
         self.assert_task_list(conductor, actual_tasks, expected_tasks)
 
         # Set the item to running status.
-        context = {'item_id': 0}
-        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [0])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -78,10 +77,10 @@ class WorkflowConductorWithItemsCancelTest(test_base.WorkflowConductorWithItemsT
         self.assertEqual(actual_task_status, statuses.CANCELING)
 
         # Change status for the item.
-        contexts = [{'item_id': 0}]
+        item_ids = [0]
         results = [task_ctx['xs'][0]]
         status_changes = [ac_ex_status]
-        self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+        self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert task and workflow status.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -157,8 +156,7 @@ class WorkflowConductorWithItemsCancelTest(test_base.WorkflowConductorWithItemsT
 
         # Set the items to running status.
         for i in range(0, len(ac_ex_statuses)):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -172,19 +170,19 @@ class WorkflowConductorWithItemsCancelTest(test_base.WorkflowConductorWithItemsT
 
         # Change status for all but one item.
         for i in range(0, len(ac_ex_statuses) - 1):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [ac_ex_statuses[i]]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
             actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
             self.assertEqual(actual_task_status, statuses.CANCELING)
 
         # Change status for the last item.
         i = len(ac_ex_statuses) - 1
-        contexts = [{'item_id': i}]
+        item_ids = [i]
         results = [task_ctx['xs'][i]]
         status_changes = [ac_ex_statuses[i]]
-        self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+        self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert task and workflow status.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']

--- a/orquesta/tests/unit/states/native/test_workflow_with_items_pause_and_resume.py
+++ b/orquesta/tests/unit/states/native/test_workflow_with_items_pause_and_resume.py
@@ -64,8 +64,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
         self.assert_task_list(conductor, actual_tasks, expected_tasks)
 
         # Set the item to running status.
-        context = {'item_id': 0}
-        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+        self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [0])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -78,10 +77,10 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
         self.assertEqual(actual_task_status, statuses.PAUSING)
 
         # Change status for the item.
-        contexts = [{'item_id': 0}]
+        item_ids = [0]
         results = [task_ctx['xs'][0]]
         status_changes = [ac_ex_status]
-        self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+        self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert task and workflow status.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -157,8 +156,7 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Set the items to running status.
         for i in range(0, len(ac_ex_statuses)):
-            context = {'item_id': i}
-            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [context])
+            self.forward_task_statuses(conductor, task_name, [statuses.RUNNING], [i])
 
         # Assert that the task is running.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
@@ -172,19 +170,19 @@ class WorkflowConductorWithItemsPauseResumeTest(test_base.WorkflowConductorWithI
 
         # Change status for all but one item.
         for i in range(0, len(ac_ex_statuses) - 1):
-            contexts = [{'item_id': i}]
+            item_ids = [i]
             results = [task_ctx['xs'][i]]
             status_changes = [ac_ex_statuses[i]]
-            self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+            self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
             actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']
             self.assertEqual(actual_task_status, statuses.PAUSING)
 
         # Change status for the last item.
         i = len(ac_ex_statuses) - 1
-        contexts = [{'item_id': i}]
+        item_ids = [i]
         results = [task_ctx['xs'][i]]
         status_changes = [ac_ex_statuses[i]]
-        self.forward_task_statuses(conductor, task_name, status_changes, contexts, results)
+        self.forward_task_statuses(conductor, task_name, status_changes, item_ids, results)
 
         # Assert task and workflow status.
         actual_task_status = conductor.workflow_state.get_task(task_name, task_route)['status']


### PR DESCRIPTION
Refactor conductor to not store individual item result for a with items task in the task state. If there are a lot of items and/or result size is huge per item, then this will be a performance impact on database write operations when recording the conductor state. A new TaskItemActionExecutionEvent is introduced to distinguish between a normal action execution event and one for an item. The accumulated result is only stored temporary in the conductor state and evaluated by the conductor when all the items have completed execution.