### PR TITLE
Separate render workflow output from update task state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Fixed
 * Fix conducting of cycle with a fork. Fixes #169 (bug fix)
 * Fix request_workflow_status to ignore certain status change errors such as pausing a workflow
   that is already pausing and canceling a workflow that is already canceling. (bug fix)
+* Remove rendering of workflow output automatically when updating task state. This caused
+  workflow output to render incorrectly in certain use case. The render_workflow_output function
+  must be called separately. (bug fix)
 
 1.0.0
 -----

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -407,7 +407,7 @@ class WorkflowConductor(object):
 
         return wf_term_ctx
 
-    def _render_workflow_outputs(self):
+    def render_workflow_output(self):
         wf_status = self.get_workflow_status()
 
         # Render workflow outputs if workflow is completed.
@@ -875,10 +875,9 @@ class WorkflowConductor(object):
             engine_event = events.ENGINE_EVENT_MAP[next_task_id]
             self.update_task_state(next_task_id, next_task_route, engine_event())
 
-        # Render workflow output if workflow is completed.
+        # Mark the task as a terminal task if workflow execution is completed.
         if self.get_workflow_status() in statuses.COMPLETED_STATUSES:
             task_state_entry['term'] = True
-            self._render_workflow_outputs()
 
         return task_state_entry
 

--- a/orquesta/tests/unit/base.py
+++ b/orquesta/tests/unit/base.py
@@ -315,6 +315,9 @@ class WorkflowConductorTest(WorkflowComposerTest):
         self.assertListEqual(actual_task_seq, expected_task_seq)
         self.assertListEqual(conductor.workflow_state.routes, expected_routes)
 
+        if conductor.get_workflow_status() in statuses.COMPLETED_STATUSES:
+            conductor.render_workflow_output()
+
         if expected_workflow_status is None:
             expected_workflow_status = statuses.SUCCEEDED
 

--- a/orquesta/tests/unit/conducting/test_workflow_conductor.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor.py
@@ -664,6 +664,8 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
             task_name = 'task' + str(i)
             self.forward_task_statuses(conductor, task_name, [statuses.RUNNING, statuses.SUCCEEDED])
 
+        # Render workflow output and check workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.RUNNING)
         self.assertIsNone(conductor.get_workflow_output())
 
@@ -680,6 +682,8 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
         task_name = 'task5'
         self.forward_task_statuses(conductor, task_name, [statuses.RUNNING, statuses.FAILED])
 
+        # Render workflow output and check workflow status and output.
+        conductor.render_workflow_output()
         expected_output = {'data': expected_task_ctx}
         self.assertEqual(conductor.get_workflow_status(), statuses.FAILED)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
@@ -694,6 +698,8 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
             task_name = 'task' + str(i)
             self.forward_task_statuses(conductor, task_name, [statuses.RUNNING, statuses.SUCCEEDED])
 
+        # Render workflow output and check workflow status and output.
+        conductor.render_workflow_output()
         expected_output = {'data': expected_task_ctx}
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_branching.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_branching.py
@@ -338,7 +338,8 @@ class WorkflowConductorExtendedTest(test_base.WorkflowConductorTest):
         expected_term_tasks = ['task2', 'task4']
         self.assertListEqual(actual_term_tasks, expected_term_tasks)
 
-        # Check workflow status and context.
+        # Render workflow output and check workflow status and context.
+        conductor.render_workflow_output()
         expected_term_ctx = {'var1': 'xyz', 'var2': 123}
         self.assertDictEqual(conductor.get_workflow_terminal_context(), expected_term_ctx)
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_cancel.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_cancel.py
@@ -52,7 +52,8 @@ class WorkflowConductorCancelTest(test_base.WorkflowConductorTest):
         conductor.request_workflow_status(statuses.CANCELING)
         self.forward_task_statuses(conductor, 'task1', [statuses.SUCCEEDED])
 
-        # Check workflow status and output.
+        # Render workflow output and check workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.CANCELED)
         self.assertListEqual(conductor.errors, expected_errors)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
@@ -100,6 +101,7 @@ class WorkflowConductorCancelTest(test_base.WorkflowConductorTest):
         self.forward_task_statuses(conductor, 'task1', [statuses.SUCCEEDED])
 
         # Check workflow status is not changed to failed given the output error.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.CANCELED)
         self.assertListEqual(conductor.errors, expected_errors)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_context.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_context.py
@@ -41,6 +41,10 @@ class WorkflowConductorContextTest(test_base.WorkflowConductorTest):
             action: core.noop
         """
 
+        # The YaqlEvaluationException on variables "x" and "y" are a result of using unassigned
+        # variables in the input and vars section. The YaqlEvaluationException on variables
+        # "a", "b", and "z" are a result of rendering workflow output with unassigned variables
+        # on workflow execution completion.
         expected_errors = [
             {
                 'type': 'error',
@@ -54,6 +58,27 @@ class WorkflowConductorContextTest(test_base.WorkflowConductorTest):
                 'message': (
                     'YaqlEvaluationException: Unable to resolve key \'y\' in '
                     'expression \'<% ctx().y %>\' from context.'
+                )
+            },
+            {
+                'type': 'error',
+                'message': (
+                    'YaqlEvaluationException: Unable to resolve key \'a\' in '
+                    'expression \'<% ctx().a %>\' from context.'
+                )
+            },
+            {
+                'type': 'error',
+                'message': (
+                    'YaqlEvaluationException: Unable to resolve key \'b\' in '
+                    'expression \'<% ctx().b %>\' from context.'
+                )
+            },
+            {
+                'type': 'error',
+                'message': (
+                    'YaqlEvaluationException: Unable to resolve key \'z\' in '
+                    'expression \'<% ctx().z %>\' from context.'
                 )
             }
         ]
@@ -69,7 +94,8 @@ class WorkflowConductorContextTest(test_base.WorkflowConductorTest):
             statuses.RUNNING
         )
 
-        # Check workflow status and result.
+        # Render workflow output and check workflow status and result.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.FAILED)
         self.assertListEqual(conductor.errors, expected_errors)
         self.assertIsNone(conductor.get_workflow_output())
@@ -115,7 +141,8 @@ class WorkflowConductorContextTest(test_base.WorkflowConductorTest):
         # Complete tasks
         self.forward_task_statuses(conductor, 'task1', [statuses.RUNNING, statuses.SUCCEEDED])
 
-        # Check workflow status and output.
+        # Render workflow output and check workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
         self.assertListEqual(conductor.errors, expected_errors)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
@@ -245,7 +272,8 @@ class WorkflowConductorContextTest(test_base.WorkflowConductorTest):
         # Complete tasks
         self.forward_task_statuses(conductor, 'task1', [statuses.RUNNING, statuses.SUCCEEDED])
 
-        # Check workflow status and output.
+        # Render workflow output and check workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.FAILED)
         self.assertListEqual(conductor.errors, expected_conducting_errors)
         self.assertIsNone(conductor.get_workflow_output())
@@ -287,7 +315,8 @@ class WorkflowConductorContextTest(test_base.WorkflowConductorTest):
         # Complete tasks
         self.forward_task_statuses(conductor, 'task1', [statuses.RUNNING, statuses.SUCCEEDED])
 
-        # Check workflow status and output.
+        # Render workflow output and check workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
         self.assertListEqual(conductor.errors, expected_errors)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_data_flow.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_data_flow.py
@@ -83,6 +83,8 @@ class WorkflowConductorDataFlowTest(test_base.WorkflowConductorTest):
             task_name = 'task' + str(i)
             self.forward_task_statuses(conductor, task_name, [statuses.RUNNING, statuses.SUCCEEDED])
 
+        # Render workflow output and checkout workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
 

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_error_handling.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_error_handling.py
@@ -944,6 +944,8 @@ class WorkflowConductorErrorHandlingTest(test_base.WorkflowConductorTest):
         # Manually complete task1.
         self.forward_task_statuses(conductor, 'task1', [statuses.RUNNING, statuses.SUCCEEDED])
 
+        # Render workflow output and checkout workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.FAILED)
         self.assertListEqual(conductor.errors, expected_errors)
         self.assertIsNone(conductor.get_workflow_output())
@@ -987,6 +989,8 @@ class WorkflowConductorErrorHandlingTest(test_base.WorkflowConductorTest):
         # Manually complete task1.
         self.forward_task_statuses(conductor, 'task1', [statuses.RUNNING, statuses.SUCCEEDED])
 
+        # Render workflow output and checkout workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.FAILED)
         self.assertListEqual(conductor.errors, expected_errors)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_performance.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_performance.py
@@ -141,5 +141,6 @@ class WorkflowConductorWithItemsStressTest(test_base.WorkflowConductorWithItemsT
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
 
         # Assert the workflow output is correct.
+        conductor.render_workflow_output()
         expected_output = {'items': task_ctx['xs']}
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_task_status.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_task_status.py
@@ -68,7 +68,8 @@ class WorkflowConductorContextTest(test_base.WorkflowConductorTest):
         # Complete task2.
         self.forward_task_statuses(conductor, 'task2', [statuses.RUNNING, statuses.SUCCEEDED])
 
-        # Check workflow status and output.
+        # Render workflow output and check workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
         self.assertListEqual(conductor.errors, expected_errors)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
@@ -123,7 +124,8 @@ class WorkflowConductorContextTest(test_base.WorkflowConductorTest):
         self.forward_task_statuses(conductor, 'task3', status_changes, route=1)
         self.forward_task_statuses(conductor, 'task3', status_changes, route=2)
 
-        # Check workflow status and output.
+        # Render workflow output and check workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
         self.assertListEqual(conductor.errors, expected_errors)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
@@ -183,7 +185,8 @@ class WorkflowConductorContextTest(test_base.WorkflowConductorTest):
         self.forward_task_statuses(conductor, 'task2', status_changes, route=1)
         self.forward_task_statuses(conductor, 'task3', status_changes, route=2)
 
-        # Check workflow status and output.
+        # Render workflow output and check workflow status and output.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
         self.assertListEqual(conductor.errors, expected_errors)
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_with_items.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_with_items.py
@@ -74,6 +74,7 @@ class WorkflowConductorWithItemsTest(test_base.WorkflowConductorWithItemsTest):
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
 
         # Assert the workflow output is correct.
+        conductor.render_workflow_output()
         expected_output = {'items': []}
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
 
@@ -141,6 +142,7 @@ class WorkflowConductorWithItemsTest(test_base.WorkflowConductorWithItemsTest):
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
 
         # Assert the workflow output is correct.
+        conductor.render_workflow_output()
         expected_output = {'items': task_ctx['xs']}
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
 
@@ -234,6 +236,7 @@ class WorkflowConductorWithItemsTest(test_base.WorkflowConductorWithItemsTest):
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
 
         # Assert the workflow output is correct.
+        conductor.render_workflow_output()
         expected_output = {'items': task_ctx['xs']}
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
 
@@ -372,6 +375,7 @@ class WorkflowConductorWithItemsTest(test_base.WorkflowConductorWithItemsTest):
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
 
         # Assert the workflow output is correct.
+        conductor.render_workflow_output()
         expected_output = {'items': ['foobar', 'fubar', 'marcopolo']}
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
 
@@ -496,6 +500,7 @@ class WorkflowConductorWithItemsTest(test_base.WorkflowConductorWithItemsTest):
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
 
         # Assert the workflow output is correct.
+        conductor.render_workflow_output()
         expected_output = {'items': [[i, j] for i, j in zip(task_ctx['xs'], task_ctx['ys'])]}
         self.assertDictEqual(conductor.get_workflow_output(), expected_output)
 
@@ -1012,4 +1017,5 @@ class WorkflowConductorWithItemsTest(test_base.WorkflowConductorWithItemsTest):
         self.assertIsNone(conductor.workflow_state.get_staged_task(task_name, task_route))
 
         # Assert the workflow succeeded.
+        conductor.render_workflow_output()
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)


### PR DESCRIPTION
In certain use case, the service using orquesta gets the final task status only after updating the task state. If the rendering of workflow output on completion of the workflow execution calls a task related function to get task status and result such as the `task` function in StackStorm, the render would return an inaccurate task state. To address this issue, the rendering of workflow output is not done by default when updating the task state. The services consuming orquesta need to render workflow output separately and explicitly. The service should update task state, then check the workflow status before rendering the workflow output.