### PR TITLE
Fix func_has_ctx_arg to use getfullargspec for py3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Fixed
 * Remove rendering of workflow output automatically when updating task state. This caused
   workflow output to render incorrectly in certain use case. The render_workflow_output function
   must be called separately. (bug fix)
+* When inspecting custom YAQL/Jinja function to see if there is a context arg, use getargspec
+  for py2 and getfullargspec for py3. (bug fix)
 
 1.0.0
 -----

--- a/orquesta/expressions/base.py
+++ b/orquesta/expressions/base.py
@@ -170,4 +170,8 @@ def extract_vars(statement):
 
 
 def func_has_ctx_arg(func):
-    return 'context' in inspect.getargspec(func).args
+    getargspec = (
+        inspect.getargspec if six.PY2 else inspect.getfullargspec  # pylint: disable=no-member
+    )
+
+    return 'context' in getargspec(func).args


### PR DESCRIPTION
When inspecting custom YAQL/Jinja function to see if there is a context arg in orquesta.expressions.base.func_has_ctx_arg, use getargspec for py2 and getfullargspec for py3.