### PR TITLE
Use ujson to deepcopy dict(s) for faster performance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changed
 * Refactor conductor to not store each item result in task state. If there are a lot of items
   and/or result size is huge per item, then there will be a performance impact on database
   write operations when recording the conductor state. (improvement)
+* Use ujson to deepcopy dict(s) for faster performance. (improvement)
 
 Fixed
 ~~~~~

--- a/orquesta/graphing.py
+++ b/orquesta/graphing.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import abc
-import copy
 import logging
 
 import networkx as nx
@@ -23,6 +22,7 @@ import six
 
 from orquesta import exceptions as exc
 from orquesta.utils import dictionary as dict_util
+from orquesta.utils import jsonify as json_util
 
 
 LOG = logging.getLogger(__name__)
@@ -49,7 +49,7 @@ class WorkflowGraph(object):
 
     @classmethod
     def deserialize(cls, data):
-        g = json_graph.adjacency_graph(copy.deepcopy(data), directed=True, multigraph=True)
+        g = json_graph.adjacency_graph(json_util.deepcopy(data), directed=True, multigraph=True)
         return cls(graph=g)
 
     @staticmethod
@@ -81,7 +81,7 @@ class WorkflowGraph(object):
             raise exc.InvalidTask(task_id)
 
         task = {'id': task_id}
-        task.update(copy.deepcopy(self._graph.node[task_id]))
+        task.update(json_util.deepcopy(self._graph.node[task_id]))
 
         return task
 

--- a/orquesta/machines.py
+++ b/orquesta/machines.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import logging
 
 from orquesta import events
 from orquesta import exceptions as exc
 from orquesta import statuses
+from orquesta.utils import jsonify as json_util
 
 
 LOG = logging.getLogger(__name__)
@@ -537,7 +537,7 @@ class TaskStateMachine(object):
         if ac_ex_event.status in requirements:
             # Make a copy of the items and remove current item under evaluation.
             staged_task = workflow_state.get_staged_task(task_id, task_route)
-            items = copy.deepcopy(staged_task['items'])
+            items = json_util.deepcopy(staged_task['items'])
             del items[ac_ex_event.item_id]
             items_status = [item.get('status', statuses.UNSET) for item in items]
 

--- a/orquesta/specs/mistral/v2/tasks.py
+++ b/orquesta/specs/mistral/v2/tasks.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import logging
 import re
 import six
@@ -24,6 +23,7 @@ from orquesta.specs.mistral.v2 import base as mistral_spec_base
 from orquesta.specs.mistral.v2 import policies as policy_models
 from orquesta.specs import types as spec_types
 from orquesta.utils import dictionary as dict_util
+from orquesta.utils import jsonify as json_util
 
 
 LOG = logging.getLogger(__name__)
@@ -300,7 +300,7 @@ class TaskMappingSpec(mistral_spec_base.MappingSpec):
         q = queue.Queue()
 
         for task in self.get_start_tasks():
-            q.put((task[0], copy.deepcopy(rolling_ctx)))
+            q.put((task[0], json_util.deepcopy(rolling_ctx)))
 
         while not q.empty():
             task_name, task_ctx = q.get()

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import logging
 import six
 from six.moves import queue
@@ -25,6 +24,7 @@ from orquesta.specs.native.v1 import base as native_v1_specs
 from orquesta.specs import types as spec_types
 from orquesta.utils import context as ctx_util
 from orquesta.utils import dictionary as dict_util
+from orquesta.utils import jsonify as json_util
 from orquesta.utils import parameters as args_util
 
 
@@ -244,7 +244,7 @@ class TaskSpec(native_v1_specs.Spec):
         return self, action_specs
 
     def finalize_context(self, next_task_name, task_transition_meta, in_ctx):
-        rolling_ctx = copy.deepcopy(in_ctx)
+        rolling_ctx = json_util.deepcopy(in_ctx)
         new_ctx = {}
         errors = []
 
@@ -526,7 +526,7 @@ class TaskMappingSpec(native_v1_specs.MappingSpec):
         q = queue.Queue()
 
         for task in self.get_start_tasks():
-            q.put((task[0], copy.deepcopy(rolling_ctx)))
+            q.put((task[0], json_util.deepcopy(rolling_ctx)))
 
         while not q.empty():
             task_name, task_ctx = q.get()
@@ -647,7 +647,7 @@ class WorkflowSpec(native_v1_specs.Spec):
         super(WorkflowSpec, self).__init__(spec, name=name, member=member)
 
     def render_input(self, runtime_inputs, in_ctx=None):
-        rolling_ctx = copy.deepcopy(in_ctx) if in_ctx else {}
+        rolling_ctx = json_util.deepcopy(in_ctx) if in_ctx else {}
         errors = []
 
         for input_spec in (getattr(self, 'input') or []):
@@ -669,7 +669,7 @@ class WorkflowSpec(native_v1_specs.Spec):
         return rolling_ctx, errors
 
     def render_vars(self, in_ctx):
-        rolling_ctx = copy.deepcopy(in_ctx)
+        rolling_ctx = json_util.deepcopy(in_ctx)
         rendered_vars = {}
         errors = []
 
@@ -688,7 +688,7 @@ class WorkflowSpec(native_v1_specs.Spec):
 
     def render_output(self, in_ctx):
         output_specs = getattr(self, 'output') or []
-        rolling_ctx = copy.deepcopy(in_ctx)
+        rolling_ctx = json_util.deepcopy(in_ctx)
         rendered_outputs = {}
         errors = []
 

--- a/orquesta/tests/unit/base.py
+++ b/orquesta/tests/unit/base.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import abc
-import copy
 import six
 from six.moves import queue
 import unittest
@@ -24,6 +23,7 @@ from orquesta.expressions import base as expr_base
 from orquesta.specs import loader as spec_loader
 from orquesta import statuses
 from orquesta.tests.fixtures import loader as fixture_loader
+from orquesta.utils import jsonify as json_util
 from orquesta.utils import plugin as plugin_util
 from orquesta.utils import specs as spec_util
 
@@ -199,12 +199,10 @@ class WorkflowConductorTest(WorkflowComposerTest):
     # order to match in unit tests. This method is used to serialize the task specs and
     # compare the lists.
     def assert_task_list(self, conductor, actual, expected):
-        actual_copy = copy.deepcopy(actual)
-        expected_copy = copy.deepcopy(expected)
+        actual_copy = json_util.deepcopy(actual)
+        expected_copy = json_util.deepcopy(expected)
 
         for task in actual_copy:
-            task['spec'] = task['spec'].serialize()
-
             for staged_task in task['ctx']['__state']['staged']:
                 if 'items' in staged_task:
                     del staged_task['items']
@@ -212,7 +210,6 @@ class WorkflowConductorTest(WorkflowComposerTest):
         for task in expected_copy:
             task['ctx']['__current_task'] = {'id': task['id'], 'route': task['route']}
             task['ctx']['__state'] = conductor.workflow_state.serialize()
-            task['spec'] = task['spec'].serialize()
 
             for staged_task in task['ctx']['__state']['staged']:
                 if 'items' in staged_task:

--- a/orquesta/tests/unit/conducting/test_workflow_conductor.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 from orquesta import conducting
 from orquesta import exceptions as exc
 from orquesta import graphing
@@ -21,6 +19,7 @@ from orquesta.specs import native as native_specs
 from orquesta import statuses
 from orquesta.tests.unit import base as test_base
 from orquesta.utils import dictionary as dict_util
+from orquesta.utils import jsonify as json_util
 
 
 class WorkflowConductorTest(test_base.WorkflowConductorTest):
@@ -235,7 +234,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
     def test_init_with_context(self):
         context = {'parent': {'ex_id': '12345'}}
         inputs = {'a': 123, 'b': True}
-        init_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), copy.deepcopy(context))
+        init_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), json_util.deepcopy(context))
 
         conductor = self._prep_conductor(context=context, inputs=inputs)
 
@@ -325,7 +324,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_start_tasks(self):
         inputs = {'a': 123}
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), {'b': False})
+        expected_task_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), {'b': False})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
         self.assert_next_task(conductor, 'task1', expected_task_ctx)
 
@@ -362,7 +361,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
         task_route = 0
         task_name = 'task1'
-        expected_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), {'b': False})
+        expected_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), {'b': False})
         expected_ctx['__current_task'] = {'id': task_name, 'route': task_route}
         expected_ctx['__state'] = conductor.workflow_state.serialize()
         task = conductor.get_task(task_name, task_route)
@@ -373,7 +372,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
         self.forward_task_statuses(conductor, task_name, [statuses.RUNNING, statuses.SUCCEEDED])
 
         task_name = 'task2'
-        expected_ctx = dict_util.merge_dicts(copy.deepcopy(expected_ctx), {'c': 'xyz'})
+        expected_ctx = dict_util.merge_dicts(json_util.deepcopy(expected_ctx), {'c': 'xyz'})
         expected_ctx['__current_task'] = {'id': task_name, 'route': task_route}
         expected_ctx['__state'] = conductor.workflow_state.serialize()
         task = conductor.get_task(task_name, task_route)
@@ -398,8 +397,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
         task_name = 'task1'
         next_task_name = 'task2'
-        expected_init_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), {'b': False})
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), {'b': False})
+        expected_task_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_task_ctx = dict_util.merge_dicts(expected_task_ctx, {'c': 'xyz'})
 
         self.assert_next_task(conductor, task_name, expected_init_ctx)
 
@@ -421,8 +421,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_next_tasks_when_this_task_paused(self):
         inputs = {'a': 123}
-        expected_init_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), {'b': False})
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), {'b': False})
+        expected_task_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_task_ctx = dict_util.merge_dicts(expected_task_ctx, {'c': 'xyz'})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         task_name = 'task1'
@@ -448,8 +449,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_next_tasks_when_graph_paused(self):
         inputs = {'a': 123}
-        expected_init_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), {'b': False})
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), {'b': False})
+        expected_task_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_task_ctx = dict_util.merge_dicts(expected_task_ctx, {'c': 'xyz'})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         task_name = 'task1'
@@ -468,8 +470,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_next_tasks_when_this_task_canceled(self):
         inputs = {'a': 123}
-        expected_init_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), {'b': False})
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), {'b': False})
+        expected_task_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_task_ctx = dict_util.merge_dicts(expected_task_ctx, {'c': 'xyz'})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         task_name = 'task1'
@@ -488,8 +491,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_next_tasks_when_graph_canceled(self):
         inputs = {'a': 123}
-        expected_init_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), {'b': False})
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), {'b': False})
+        expected_task_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_task_ctx = dict_util.merge_dicts(expected_task_ctx, {'c': 'xyz'})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         task_name = 'task1'
@@ -505,8 +509,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_next_tasks_when_this_task_abended(self):
         inputs = {'a': 123}
-        expected_init_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), {'b': False})
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), {'b': False})
+        expected_task_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_task_ctx = dict_util.merge_dicts(expected_task_ctx, {'c': 'xyz'})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         task_name = 'task1'
@@ -523,8 +528,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_next_tasks_when_graph_abended(self):
         inputs = {'a': 123}
-        expected_init_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), {'b': False})
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), {'b': False})
+        expected_task_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_task_ctx = dict_util.merge_dicts(expected_task_ctx, {'c': 'xyz'})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         task_name = 'task1'
@@ -537,7 +543,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_task_initial_context(self):
         inputs = {'a': 123}
-        expected_init_ctx = dict_util.merge_dicts(copy.deepcopy(inputs), {'b': False})
+        expected_init_ctx = dict_util.merge_dicts(json_util.deepcopy(inputs), {'b': False})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         task_route = 0
@@ -553,8 +559,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_task_transition_contexts(self):
         inputs = {'a': 123, 'b': True}
-        expected_init_ctx = copy.deepcopy(inputs)
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = json_util.deepcopy(inputs)
+        expected_task_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_task_ctx = dict_util.merge_dicts(expected_task_ctx, {'c': 'xyz'})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         # Get context for task2 that is staged by not yet running.
@@ -645,8 +652,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_workflow_terminal_context_when_workflow_completed(self):
         inputs = {'a': 123, 'b': True}
-        expected_init_ctx = copy.deepcopy(inputs)
-        expected_term_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = json_util.deepcopy(inputs)
+        expected_term_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_term_ctx = dict_util.merge_dicts(expected_term_ctx, {'c': 'xyz'})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         for i in range(1, 6):
@@ -671,8 +679,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_workflow_output_when_workflow_failed(self):
         inputs = {'a': 123, 'b': True}
-        expected_init_ctx = copy.deepcopy(inputs)
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = json_util.deepcopy(inputs)
+        expected_task_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_task_ctx = dict_util.merge_dicts(expected_task_ctx, {'c': 'xyz'})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         for i in range(1, 5):
@@ -690,8 +699,9 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
     def test_get_workflow_output_when_workflow_succeeded(self):
         inputs = {'a': 123, 'b': True}
-        expected_init_ctx = copy.deepcopy(inputs)
-        expected_task_ctx = dict_util.merge_dicts(copy.deepcopy(expected_init_ctx), {'c': 'xyz'})
+        expected_init_ctx = json_util.deepcopy(inputs)
+        expected_task_ctx = json_util.deepcopy(expected_init_ctx)
+        expected_task_ctx = dict_util.merge_dicts(expected_task_ctx, {'c': 'xyz'})
         conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING)
 
         for i in range(1, 6):

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_branching.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_branching.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 from orquesta import conducting
 from orquesta.specs import native as native_specs
 from orquesta import statuses
 from orquesta.tests.unit import base as test_base
 from orquesta.utils import dictionary as dict_util
+from orquesta.utils import jsonify as json_util
 
 
 class WorkflowConductorExtendedTest(test_base.WorkflowConductorTest):
@@ -99,7 +98,7 @@ class WorkflowConductorExtendedTest(test_base.WorkflowConductorTest):
         self.assert_next_task(conductor, has_next_task=False)
 
         # Check workflow status and context.
-        expected_term_ctx = copy.deepcopy(expected_task_ctx)
+        expected_term_ctx = json_util.deepcopy(expected_task_ctx)
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
         self.assertDictEqual(conductor.get_workflow_terminal_context(), expected_term_ctx)
 
@@ -222,7 +221,7 @@ class WorkflowConductorExtendedTest(test_base.WorkflowConductorTest):
 
         # Succeed task1 and check context.
         self.forward_task_statuses(conductor, 'task1', [statuses.SUCCEEDED])
-        expected_task_ctx = copy.deepcopy(inputs)
+        expected_task_ctx = json_util.deepcopy(inputs)
         expected_txsn_ctx = {'task3__t0': expected_task_ctx}
         self.assertDictEqual(conductor.get_task_transition_contexts('task1', 0), expected_txsn_ctx)
         self.assert_next_task(conductor, has_next_task=False)
@@ -245,7 +244,7 @@ class WorkflowConductorExtendedTest(test_base.WorkflowConductorTest):
         self.assert_next_task(conductor, has_next_task=False)
 
         # Check workflow status and context.
-        expected_term_ctx = copy.deepcopy(expected_task_ctx)
+        expected_term_ctx = json_util.deepcopy(expected_task_ctx)
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
         self.assertDictEqual(conductor.get_workflow_terminal_context(), expected_term_ctx)
 

--- a/orquesta/tests/unit/expressions/functions/test_workflow.py
+++ b/orquesta/tests/unit/expressions/functions/test_workflow.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import unittest
 
 from orquesta import constants
 from orquesta import exceptions as exc
 from orquesta.expressions.functions import workflow as funcs
 from orquesta import statuses
+from orquesta.utils import jsonify as json_util
 
 
 class WorkflowFunctionTest(unittest.TestCase):
@@ -296,7 +296,7 @@ class WorkflowFunctionTest(unittest.TestCase):
         }
 
         # Check the task statuses along route 1.
-        current_ctx = copy.deepcopy(context)
+        current_ctx = json_util.deepcopy(context)
         current_ctx['__current_task'] = {'id': 't6', 'route': 1}
         self.assertEqual(funcs.task_status_(current_ctx, 't1'), statuses.SUCCEEDED)
         self.assertEqual(funcs.task_status_(current_ctx, 't2'), statuses.SUCCEEDED)
@@ -306,7 +306,7 @@ class WorkflowFunctionTest(unittest.TestCase):
         self.assertEqual(funcs.task_status_(current_ctx, 't6'), statuses.SUCCEEDED)
 
         # Check the task statuses along route 2.
-        current_ctx = copy.deepcopy(context)
+        current_ctx = json_util.deepcopy(context)
         current_ctx['__current_task'] = {'id': 't6', 'route': 2}
         self.assertEqual(funcs.task_status_(current_ctx, 't1'), statuses.SUCCEEDED)
         self.assertEqual(funcs.task_status_(current_ctx, 't2'), statuses.SUCCEEDED)
@@ -367,7 +367,7 @@ class WorkflowFunctionTest(unittest.TestCase):
         }
 
         # Check the task statuses along route 1.
-        current_ctx = copy.deepcopy(context)
+        current_ctx = json_util.deepcopy(context)
         current_ctx['__current_task'] = {'id': 't7', 'route': 3}
         self.assertEqual(funcs.task_status_(current_ctx, 't1'), statuses.SUCCEEDED)
         self.assertEqual(funcs.task_status_(current_ctx, 't2'), statuses.SUCCEEDED)
@@ -378,7 +378,7 @@ class WorkflowFunctionTest(unittest.TestCase):
         self.assertEqual(funcs.task_status_(current_ctx, 't7'), statuses.SUCCEEDED)
 
         # Check the task statuses along route 2.
-        current_ctx = copy.deepcopy(context)
+        current_ctx = json_util.deepcopy(context)
         current_ctx['__current_task'] = {'id': 't7', 'route': 4}
         self.assertEqual(funcs.task_status_(current_ctx, 't1'), statuses.SUCCEEDED)
         self.assertEqual(funcs.task_status_(current_ctx, 't2'), statuses.SUCCEEDED)
@@ -389,7 +389,7 @@ class WorkflowFunctionTest(unittest.TestCase):
         self.assertEqual(funcs.task_status_(current_ctx, 't7'), statuses.FAILED)
 
         # Check the task statuses along route 3.
-        current_ctx = copy.deepcopy(context)
+        current_ctx = json_util.deepcopy(context)
         current_ctx['__current_task'] = {'id': 't7', 'route': 5}
         self.assertEqual(funcs.task_status_(current_ctx, 't1'), statuses.SUCCEEDED)
         self.assertEqual(funcs.task_status_(current_ctx, 't2'), statuses.SUCCEEDED)
@@ -400,7 +400,7 @@ class WorkflowFunctionTest(unittest.TestCase):
         self.assertEqual(funcs.task_status_(current_ctx, 't7'), statuses.RUNNING)
 
         # Check the task statuses along route 4.
-        current_ctx = copy.deepcopy(context)
+        current_ctx = json_util.deepcopy(context)
         current_ctx['__current_task'] = {'id': 't7', 'route': 6}
         self.assertEqual(funcs.task_status_(current_ctx, 't1'), statuses.SUCCEEDED)
         self.assertEqual(funcs.task_status_(current_ctx, 't2'), statuses.SUCCEEDED)

--- a/orquesta/tests/unit/expressions/test_yaql_ctx_query.py
+++ b/orquesta/tests/unit/expressions/test_yaql_ctx_query.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 from orquesta.tests.unit import base as test_base
+from orquesta.utils import jsonify as json_util
 
 
 MOCK_LIST_DATA = {
@@ -102,7 +101,7 @@ class YAQLContextQueryTest(test_base.ExpressionEvaluatorTest):
         self.assertDictEqual(self.evaluator.evaluate(expr, MOCK_LIST_DATA), expected_result)
 
     def test_ctx_list_to_dict_transform(self):
-        expected_result = copy.deepcopy(MOCK_DICT_DATA)
+        expected_result = json_util.deepcopy(MOCK_DICT_DATA)
 
         expr = '<% dict(vms=>dict(ctx(vms).select([$.name, $]))) %>'
         self.assertListEqual([], self.evaluator.validate(expr))

--- a/orquesta/tests/unit/graphing/test_workflow_graph.py
+++ b/orquesta/tests/unit/graphing/test_workflow_graph.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 from orquesta import exceptions as exc
 from orquesta import graphing
 from orquesta.tests.unit import base as test_base
+from orquesta.utils import jsonify as json_util
 
 
 EXPECTED_WF_GRAPH = {
@@ -196,7 +195,7 @@ class WorkflowGraphTest(test_base.WorkflowGraphTest):
 
         wf_graph.add_transition('task1', 'task2', attr1='fubar')
 
-        expected_wf_graph = copy.deepcopy(EXPECTED_WF_GRAPH)
+        expected_wf_graph = json_util.deepcopy(EXPECTED_WF_GRAPH)
         expected_transition = {'id': 'task2', 'key': 1, 'attr1': 'fubar'}
         expected_wf_graph['adjacency'][0].append(expected_transition)
 

--- a/orquesta/tests/unit/specs/test_base_spec.py
+++ b/orquesta/tests/unit/specs/test_base_spec.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import six
 import unittest
 
 from orquesta import exceptions as exc
 from orquesta.specs import types as spec_types
 from orquesta.tests.unit.specs import base as test_specs
+from orquesta.utils import jsonify as json_util
 
 
 class SpecTest(unittest.TestCase):
@@ -389,19 +389,19 @@ class SpecTest(unittest.TestCase):
         spec_obj_json = spec_obj.serialize()
 
         # Test missing catalog information.
-        test_json = copy.deepcopy(spec_obj_json)
+        test_json = json_util.deepcopy(spec_obj_json)
         test_json.pop('catalog')
 
         self.assertRaises(ValueError, test_specs.MockSpec.deserialize, test_json)
 
         # Test missing version information.
-        test_json = copy.deepcopy(spec_obj_json)
+        test_json = json_util.deepcopy(spec_obj_json)
         test_json.pop('version')
 
         self.assertRaises(ValueError, test_specs.MockSpec.deserialize, test_json)
 
         # Test mismatch version information.
-        test_json = copy.deepcopy(spec_obj_json)
+        test_json = json_util.deepcopy(spec_obj_json)
         test_json['version'] = '99.99'
 
         self.assertRaises(ValueError, test_specs.MockSpec.deserialize, test_json)

--- a/orquesta/tests/unit/specs/test_base_spec_serialize.py
+++ b/orquesta/tests/unit/specs/test_base_spec_serialize.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import unittest
 
 from orquesta.tests.unit.specs import base as test_specs
+from orquesta.utils import jsonify as json_util
 
 
 class SpecTest(unittest.TestCase):
@@ -154,19 +154,19 @@ class SpecTest(unittest.TestCase):
         spec_obj_json = spec_obj.serialize()
 
         # Test missing catalog information.
-        test_json = copy.deepcopy(spec_obj_json)
+        test_json = json_util.deepcopy(spec_obj_json)
         test_json.pop('catalog')
 
         self.assertRaises(ValueError, test_specs.MockSpec.deserialize, test_json)
 
         # Test missing version information.
-        test_json = copy.deepcopy(spec_obj_json)
+        test_json = json_util.deepcopy(spec_obj_json)
         test_json.pop('version')
 
         self.assertRaises(ValueError, test_specs.MockSpec.deserialize, test_json)
 
         # Test mismatch version information.
-        test_json = copy.deepcopy(spec_obj_json)
+        test_json = json_util.deepcopy(spec_obj_json)
         test_json['version'] = '99.99'
 
         self.assertRaises(ValueError, test_specs.MockSpec.deserialize, test_json)

--- a/orquesta/tests/unit/utils/test_context.py
+++ b/orquesta/tests/unit/utils/test_context.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import unittest
 
 from orquesta.utils import context as ctx_util
+from orquesta.utils import jsonify as json_util
 
 
 class ContextUtilTest(unittest.TestCase):
@@ -25,7 +25,9 @@ class ContextUtilTest(unittest.TestCase):
         task = {'id': 't1', 'route': 0}
 
         context = ctx_util.set_current_task(context, task)
-        expected_context = dict([('__current_task', copy.deepcopy(task))] + list(context.items()))
+        expected_context = dict(
+            [('__current_task', json_util.deepcopy(task))] + list(context.items())
+        )
 
         self.assertDictEqual(context, expected_context)
 
@@ -34,7 +36,9 @@ class ContextUtilTest(unittest.TestCase):
         task = {'id': 't1', 'route': 0, 'result': 'foobar'}
 
         context = ctx_util.set_current_task(context, task)
-        expected_context = dict([('__current_task', copy.deepcopy(task))] + list(context.items()))
+        expected_context = dict(
+            [('__current_task', json_util.deepcopy(task))] + list(context.items())
+        )
 
         self.assertDictEqual(context, expected_context)
 
@@ -42,7 +46,7 @@ class ContextUtilTest(unittest.TestCase):
         task = {'id': 't1', 'route': 0}
 
         context = ctx_util.set_current_task(None, task)
-        expected_context = {'__current_task': copy.deepcopy(task)}
+        expected_context = {'__current_task': json_util.deepcopy(task)}
 
         self.assertDictEqual(context, expected_context)
 
@@ -50,7 +54,7 @@ class ContextUtilTest(unittest.TestCase):
         task = {'id': 't1', 'route': 0}
 
         context = ctx_util.set_current_task(dict(), task)
-        expected_context = {'__current_task': copy.deepcopy(task)}
+        expected_context = {'__current_task': json_util.deepcopy(task)}
 
         self.assertDictEqual(context, expected_context)
 

--- a/orquesta/tests/unit/utils/test_dictionary.py
+++ b/orquesta/tests/unit/utils/test_dictionary.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import unittest
 
 from orquesta.utils import dictionary as dict_util
+from orquesta.utils import jsonify as json_util
 
 
 LEFT = {
@@ -42,8 +42,8 @@ RIGHT = {
 class DictUtilsTest(unittest.TestCase):
 
     def test_dict_merge_overwrite(self):
-        left = copy.deepcopy(LEFT)
-        right = copy.deepcopy(RIGHT)
+        left = json_util.deepcopy(LEFT)
+        right = json_util.deepcopy(RIGHT)
 
         dict_util.merge_dicts(left, right)
 
@@ -63,8 +63,8 @@ class DictUtilsTest(unittest.TestCase):
         self.assertDictEqual(left, expected)
 
     def test_dict_merge_overwrite_false(self):
-        left = copy.deepcopy(LEFT)
-        right = copy.deepcopy(RIGHT)
+        left = json_util.deepcopy(LEFT)
+        right = json_util.deepcopy(RIGHT)
 
         dict_util.merge_dicts(left, right, overwrite=False)
 

--- a/orquesta/utils/context.py
+++ b/orquesta/utils/context.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import logging
+
+from orquesta.utils import jsonify as json_util
 
 
 LOG = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ def set_current_task(context, task):
     if not isinstance(task, dict):
         raise TypeError('The task is not type of dict.')
 
-    ctx = copy.deepcopy(context) if context else dict()
+    ctx = json_util.deepcopy(context) if context else dict()
 
     ctx['__current_task'] = {
         'id': task.get('id'),
@@ -46,7 +47,7 @@ def set_current_item(context, item):
     if context and not isinstance(context, dict):
         raise TypeError('The context is not type of dict.')
 
-    ctx = copy.deepcopy(context) if context else dict()
+    ctx = json_util.deepcopy(context) if context else dict()
     ctx['__current_item'] = item
 
     return ctx

--- a/orquesta/utils/jsonify.py
+++ b/orquesta/utils/jsonify.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import datetime
 import logging
-
 import six
+import ujson
 
 from orquesta.utils import date as date_util
 
@@ -53,3 +54,15 @@ def deserialize(obj_type, data):
             setattr(obj, k, v)
 
     return obj
+
+
+def deepcopy(value):
+    # NOTE: ujson round-trip is up to 10 times faster on smaller and larger dicts compared
+    # to copy.deepcopy(), but it has some edge cases with non-simple types such as datetimes.
+    try:
+        value = ujson.loads(ujson.dumps(value))  # pylint: disable=no-member
+    except (OverflowError, ValueError):
+        # NOTE: ujson doesn't support 5 or 6 bytes utf-8 sequences so we fallback to copy.deepcopy.
+        value = copy.deepcopy(value)
+
+    return value

--- a/orquesta/utils/schema.py
+++ b/orquesta/utils/schema.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Use copy.deepcopy instead of orquesta.utils.jsonify.deepcopy because
+# the schema contains instance(s) of Spec class(es) in which the
+# jsonify.deepcopy method will convert the Spec class(es) to dict.
 import copy
 
 from orquesta import exceptions as exc

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ python-dateutil
 PyYAML>=3.1.0 # MIT
 six>=1.9.0
 stevedore>=1.3.0 # Apache-2.0
+ujson>=1.35 # BSD License
 yaql>=1.1.0 # Apache-2.0


### PR DESCRIPTION
Use ujson for copying dict(s) instead of copy.deepcopy for better performance. There are specific cases where we have to continue using copy.deepcopy, specifically in merging schema because it contains Spec class(es).