### PR TITLE
Fixed a problem not to be able to parse input value which is type of dict in array in some YAQL operators.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,9 @@ Fixed
 * Check syntax on with items task to ensure action is indented correctly. Fixes #184 (bug fix)
 * Fix variable inspection where ctx().get() method calls are identified as errors.
   Fixes StackStorm/st2#4866 (bug fix)
+* Fix a problem of TypeError orccuring when a list (or dict) value that contains unhashable typed
+  value (list or dict) is passed in some YAQL operators (e.g. distinct()). Fixes #176 (bug fix)
+  Contributed by Hiroyasu Ohyama (@userlocalhost)
 
 1.0.0
 -----

--- a/orquesta/expressions/functions/workflow.py
+++ b/orquesta/expressions/functions/workflow.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
+
 from orquesta import constants
 from orquesta import exceptions as exc
 from orquesta import statuses
@@ -115,8 +117,8 @@ def item_(context, key=None):
     if not key:
         return current_item
 
-    if not isinstance(current_item, dict):
-        raise exc.ExpressionEvaluationException('Item is not type of dict.')
+    if not isinstance(current_item, collections.Mapping):
+        raise exc.ExpressionEvaluationException('Item is not type of collections.Mapping.')
 
     if key not in current_item:
         raise exc.ExpressionEvaluationException('Item does not have key "%s".' % key)

--- a/orquesta/expressions/yql.py
+++ b/orquesta/expressions/yql.py
@@ -72,7 +72,15 @@ class YAQLEvaluator(expr_base.Evaluator):
     @classmethod
     def contextualize(cls, data):
         ctx = cls._root_ctx.create_child_context()
-        ctx['__vars'] = yaql_utils.convert_input_data(data or {})
+
+        # Some yaql expressions (e.g. distinct()) refer to hash value of variable.
+        # But some built-in Python type values (e.g. list and dict) don't have __hash__() method.
+        # The convert_input_data method parses specified variable and convert it to hashable one.
+        if isinstance(data, yaql_utils.SequenceType) or isinstance(data, yaql_utils.MappingType):
+            ctx['__vars'] = yaql_utils.convert_input_data(data)
+        else:
+            ctx['__vars'] = data or {}
+
         ctx['__state'] = ctx['__vars'].get('__state')
         ctx['__current_task'] = ctx['__vars'].get('__current_task')
         ctx['__current_item'] = ctx['__vars'].get('__current_item')

--- a/orquesta/expressions/yql.py
+++ b/orquesta/expressions/yql.py
@@ -19,6 +19,7 @@ import six
 
 import yaql
 import yaql.language.exceptions as yaql_exc
+import yaql.language.utils as yaql_utils
 
 from orquesta import exceptions as exc
 from orquesta.expressions import base as expr_base
@@ -71,7 +72,7 @@ class YAQLEvaluator(expr_base.Evaluator):
     @classmethod
     def contextualize(cls, data):
         ctx = cls._root_ctx.create_child_context()
-        ctx['__vars'] = data or {}
+        ctx['__vars'] = yaql_utils.convert_input_data(data or {})
         ctx['__state'] = ctx['__vars'].get('__state')
         ctx['__current_task'] = ctx['__vars'].get('__current_task')
         ctx['__current_item'] = ctx['__vars'].get('__current_item')

--- a/orquesta/tests/unit/conducting/native/test_task_rendering_for_with_items.py
+++ b/orquesta/tests/unit/conducting/native/test_task_rendering_for_with_items.py
@@ -82,7 +82,7 @@ class WorkflowConductorWithItemsTaskRenderingTest(test_base.WorkflowConductorTes
                 'type': 'error',
                 'message': (
                     'YaqlEvaluationException: Unable to evaluate expression \'<% item(x) %>\'. '
-                    'ExpressionEvaluationException: Item is not type of dict.'
+                    'ExpressionEvaluationException: Item is not type of collections.Mapping.'
                 ),
                 'task_id': 'task1',
                 'route': 0

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_data_flow.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_data_flow.py
@@ -20,6 +20,7 @@ from orquesta import conducting
 from orquesta.specs import native as native_specs
 from orquesta import statuses
 from orquesta.tests.unit import base as test_base
+import yaql.language.utils as yaql_utils
 
 
 class WorkflowConductorDataFlowTest(test_base.WorkflowConductorTest):
@@ -142,10 +143,16 @@ class WorkflowConductorDataFlowTest(test_base.WorkflowConductorTest):
         self.assert_data_flow(None)
 
     def test_data_flow_dict(self):
-        self.assert_data_flow(self._get_combined_value())
+        mapping_typed_data = self._get_combined_value()
+
+        self.assertIsInstance(mapping_typed_data, yaql_utils.MappingType)
+        self.assert_data_flow(mapping_typed_data)
 
     def test_data_flow_list(self):
-        self.assert_data_flow(list(self._get_combined_value().values()))
+        sequence_typed_data = list(self._get_combined_value().values())
+
+        self.assertIsInstance(sequence_typed_data, yaql_utils.SequenceType)
+        self.assert_data_flow(sequence_typed_data)
 
     def test_data_flow_unicode(self):
         self.assert_unicode_data_flow('光合作用')

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_data_flow.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_data_flow.py
@@ -76,6 +76,25 @@ class WorkflowConductorDataFlowTest(test_base.WorkflowConductorTest):
 
         return conductor
 
+    def _get_combined_value(self, callstack_depth=0):
+        # This returns dict typed value all Python built-in type values
+        # which orquesta spec could accept.
+        if callstack_depth < 2:
+            return {
+                'null': None,
+                'integer_positive': 123,
+                'integer_negative': -123,
+                'number_positive': 99.99,
+                'number_negative': -99.99,
+                'string': 'xyz',
+                'boolean_true': True,
+                'boolean_false': False,
+                'array': list(self._get_combined_value(callstack_depth + 1).values()),
+                'object': self._get_combined_value(callstack_depth + 1),
+            }
+        else:
+            return {}
+
     def assert_data_flow(self, input_value):
         inputs = {'a1': input_value}
         expected_output = {'a5': inputs['a1'], 'b5': inputs['a1']}
@@ -119,11 +138,14 @@ class WorkflowConductorDataFlowTest(test_base.WorkflowConductorTest):
         self.assert_data_flow(True)
         self.assert_data_flow(False)
 
+    def test_data_flow_none(self):
+        self.assert_data_flow(None)
+
     def test_data_flow_dict(self):
-        self.assert_data_flow({'x': 123, 'y': 'abc'})
+        self.assert_data_flow(self._get_combined_value())
 
     def test_data_flow_list(self):
-        self.assert_data_flow([123, 'abc', True])
+        self.assert_data_flow(list(self._get_combined_value().values()))
 
     def test_data_flow_unicode(self):
         self.assert_unicode_data_flow('光合作用')

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_data_flow.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_data_flow.py
@@ -25,7 +25,7 @@ import yaql.language.utils as yaql_utils
 
 class WorkflowConductorDataFlowTest(test_base.WorkflowConductorTest):
 
-    WF_DEF_YAQL = """
+    wf_def_yaql = """
     version: 1.0
 
     description: A basic sequential workflow.
@@ -61,7 +61,7 @@ class WorkflowConductorDataFlowTest(test_base.WorkflowConductorTest):
         action: core.noop
     """
 
-    WF_DEF_JSON = """
+    wf_def_jinja = """
     version: 1.0
 
     description: A basic sequential workflow.
@@ -97,8 +97,8 @@ class WorkflowConductorDataFlowTest(test_base.WorkflowConductorTest):
         action: core.noop
     """
 
-    def _prep_conductor(self, context=None, inputs=None, status=None, wf_def=None):
-        spec = native_specs.WorkflowSpec(wf_def or self.WF_DEF_YAQL)
+    def _prep_conductor(self, wf_def, context=None, inputs=None, status=None):
+        spec = native_specs.WorkflowSpec(wf_def)
         self.assertDictEqual(spec.inspect(), {})
 
         kwargs = {
@@ -135,13 +135,13 @@ class WorkflowConductorDataFlowTest(test_base.WorkflowConductorTest):
     def _assert_data_flow(self, inputs, expected_output):
         # This assert method checks input value would be handled and published
         # as an expected type and value with both YAQL and Jinja expressions.
-        for wf_def in [self.WF_DEF_JSON, self.WF_DEF_YAQL]:
-            conductor = self._prep_conductor(inputs=inputs, status=statuses.RUNNING, wf_def=wf_def)
+        for wf_def in [self.wf_def_jinja, self.wf_def_yaql]:
+            conductor = self._prep_conductor(wf_def, inputs=inputs, status=statuses.RUNNING)
 
             for i in range(1, len(conductor.spec.tasks) + 1):
                 task_name = 'task' + str(i)
-                self.forward_task_statuses(conductor, task_name,
-                                           [statuses.RUNNING, statuses.SUCCEEDED])
+                forward_statuses = [statuses.RUNNING, statuses.SUCCEEDED]
+                self.forward_task_statuses(conductor, task_name, forward_statuses)
 
             # Render workflow output and checkout workflow status and output.
             conductor.render_workflow_output()

--- a/orquesta/tests/unit/expressions/test_facade_yaql_evaluate.py
+++ b/orquesta/tests/unit/expressions/test_facade_yaql_evaluate.py
@@ -269,3 +269,24 @@ class YAQLFacadeEvaluationTest(unittest.TestCase):
             expr_base.evaluate,
             expr
         )
+
+    def test_distinct_operator(self):
+        test_cases = [
+            {
+                'expr': '<% ctx(val).distinct() %>',
+                'input': {'val': [1, 2, 3, 1]},
+                'expect': [1, 2, 3]
+            },
+            {
+                'expr': '<% ctx(val).distinct() %>',
+                'input': {'val': [{'a': 1}, {'b': 2}, {'a': 1}]},
+                'expect': [{'a': 1}, {'b': 2}]
+            },
+            {
+                'expr': '<% ctx(val).distinct($[1]) %>',
+                'input': {'val': [['a', 1], ['b', 2], ['c', 1], ['a', 3]]},
+                'expect': [['a', 1], ['b', 2], ['a', 3]]
+            }
+        ]
+        for case in test_cases:
+            self.assertEqual(case['expect'], expr_base.evaluate(case['expr'], case['input']))


### PR DESCRIPTION
## Abstract
This fixes a problem not to be able to parse data which is typed dict(etc) in array in some YAQL operators by converting input data-structure from unhashable value to hashable one. (c.f. #176)

## Problem
Orquesta couldn't handle dict in array typed value in some yqal operators (e.g. `distinct`) as below.

```
username@host:~$ cd st2
username@host:~/st2$ source virtualenv/bin/activate; python

>>> from orquesta.expressions import base as expr_base
>>>

# It's OK when an array that has string values is passed to distinct()
>>> data = {'val': ['foo', 'bar', 'foo']}
>>> expr_base.evaluate("<% ctx(val) %>", data)
['foo', 'bar', 'foo']
>>> expr_base.evaluate("<% ctx(val).distinct() %>", data)
['foo', 'bar']
>>>

# It'll be failed when an array that has dict values is passed to distinct()
>>> data = {'val': [{'a': 1}, {'b': 2}, {'a': 1}]}
>>> expr_base.evaluate("<% ctx(val) %>", data)
[{'a': 1}, {'b': 2}, {'a': 1}]
>>> expr_base.evaluate("<% ctx(val).distinct() %>", data) 
(TypeError exception will be occurred)
```

<details>
<summary>Execution Result</summary>
<img width="731" alt="スクリーンショット 2020-04-01 15 09 11" src="https://user-images.githubusercontent.com/469934/78104860-d9d0a700-742a-11ea-861a-6fc1fe54c621.png">
</details>

## Cause & Measure
In some YAQL operators (e.g. `distinct`) refer to hash value of input data to identify it. And the [openstack/YAQL](https://github.com/openstack/yaql) library that Orquesta uses wraps those input value using [utils.convert_output_data](https://github.com/openstack/yaql/blob/master/yaql/language/utils.py#L65) to prevent TypeError exception when these operator's implementation try to refer to input hash value. Thus, we can handle these value in the `distinct` operator like following. And this PR applies it to the Orquesta.

(c.f.  https://github.com/openstack/yaql/commit/67d58bc17fcbba532764091dec0a68a4c9dbb180)

```
username@host:~$ cd st2
username@host:~/st2$ source virtualenv/bin/activate; python

>>> import yaql
>>> 
>>> engine = yaql.language.factory.YaqlFactory().create()
>>> 
>>> data = {'val': [{'a': 1}, {'b': 2}, {'a': 1}]}
>>> 
>>> engine('$.val').evaluate(data=data)
[{'a': 1}, {'b': 2}, {'a': 1}]
>>> engine('$.val.distinct()').evaluate(data=data)
[{'a': 1}, {'b': 2}]
>>> 
```

<details>
<summary>Execution Result</summary>
<img width="428" alt="スクリーンショット 2020-03-24 15 22 37" src="https://user-images.githubusercontent.com/469934/77397762-89819580-6de9-11ea-9d16-b085cc85fdb2.png">
</details>