### PR TITLE
Fixed major version of ujson to 1.x because next major release of it won't get along with current orquesta.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ python-dateutil
 PyYAML>=3.1.0 # MIT
 six>=1.9.0
 stevedore>=1.3.0 # Apache-2.0
-ujson>=1.35 # BSD License
+ujson>=1.35,<2.0 # BSD License
 yaql>=1.1.0 # Apache-2.0


### PR DESCRIPTION
This is a workaround of (#192) to avoid serialize error when [deepcopy()](https://github.com/StackStorm/orquesta/blob/master/orquesta/utils/jsonify.py#L59) which is passed task object (which is generated by [Conductor.get_task()](https://github.com/StackStorm/orquesta/blob/master/orquesta/conducting.py#L521)) is called.