### PR TITLE
Refactor evaluation of inbound criteria for join task

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Changed
   and/or result size is huge per item, then there will be a performance impact on database
   write operations when recording the conductor state. (improvement)
 * Use ujson to deepcopy dict(s) for faster performance. (improvement)
+* Refactor how inbound criteria for join task is evaluated to count by task completion
+  instead of task transition. (improvement)
 
 Fixed
 ~~~~~

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY3 := /usr/bin/python3
+PY3 := $(shell which python3)
 
 # Virtual Environment
 VENV_DIR ?= .venv
@@ -40,7 +40,7 @@ clean:
 
 .PHONY: venv
 venv:
-	test -d $(VENV_DIR) || virtualenv --no-site-packages $(VENV_DIR)
+	test -d $(VENV_DIR) || virtualenv -p $(PY3) --no-site-packages $(VENV_DIR)
 
 .PHONY: reqs
 reqs: venv

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,12 @@
 # limitations under the License.
 
 PY3 := /usr/bin/python3
-VER := $(shell cat ./orquesta/__init__.py | grep -Po "__version__ = '\K[^']*")
 
 # Virtual Environment
 VENV_DIR ?= .venv
+
+# Tox Environment
+TOX_DIR ?= .tox
 
 # Sphinx Document Options
 SPHINXOPTS    =
@@ -31,6 +33,7 @@ PKGBUILDDIR   = build
 .PHONY: clean
 clean:
 	rm -rf $(VENV_DIR)
+	rm -rf $(TOX_DIR)
 	rm -rf $(BUILDDIR)
 	rm -rf $(PKGDISTDIR)
 	rm -rf $(PKGBUILDDIR)
@@ -52,6 +55,10 @@ reqs: venv
 schemas: reqs
 	$(VENV_DIR)/bin/python bin/orquesta-generate-schemas
 
+.PHONY: check
+check:
+	tox
+
 .PHONY: docs
 docs: reqs
 	rm -rf $(BUILDDIR)
@@ -67,3 +74,6 @@ package:
 	rm -rf $(PKGDISTDIR)
 	rm -rf $(PKGBUILDDIR)
 	$(PY3) setup.py sdist bdist_wheel
+
+.PHONY: all
+all: clean reqs schemas check package

--- a/docs/source/languages/orquesta.rst
+++ b/docs/source/languages/orquesta.rst
@@ -259,13 +259,14 @@ The following is the corresponding workflow execution graph.
 
     setup_task --+
                  |
-                 +-- parallel_task_1 --+
-                 |                     |
-                 +-- parallel_task_2 --+
-                 |                     |
-                 +-- parallel_task_3 --+
-                                       |
-                                       +-- barrier_task (only requires 2 of 3 tasks) --+
+                 +-- parallel_task_1 * * * * * *
+                 |                             *
+                 +-- parallel_task_2 * * * *   *
+                 |                         *   *
+                 +-- parallel_task_3 * *   *   *
+                                       *   *   *
+                                       *   *   *
+                                       * * barrier_task (only requires 2 of 3 tasks) --+
                                                                                        |
                                                                                        +-- [finish]
 

--- a/docs/source/languages/orquesta.rst
+++ b/docs/source/languages/orquesta.rst
@@ -209,7 +209,7 @@ be run two different times, resulting in this execution graph:
                                                                                       +-- [finish]
 
 An alternative use case of join is to specify an integer value such as ``join: <integer>``
-instead of ``join: all``. In this use case, the join is satisified when the number of task
+instead of ``join: all``. In this use case, the join is satisified when the number of tasks
 transitioned into the join is greater than or equal to the value specified. Take the following
 workflow definition below, which is a revised version of the workflow from previous example.
 There are three tasks that run in parallel and will join at the barrier task. The join has a

--- a/docs/source/languages/orquesta.rst
+++ b/docs/source/languages/orquesta.rst
@@ -122,7 +122,6 @@ will be blocked until all the parallel branches complete and reach it.
 
     tasks:
       setup_task:
-        # ...
         # Run tasks in parallel
         next:
           - do:
@@ -131,34 +130,34 @@ will be blocked until all the parallel branches complete and reach it.
               - parallel_task_3
 
       parallel_task_1:
-        # ...
         # Wait to run barrier_task after this
+        action: core.noop
         next:
-          - do:
-              - barrier_task
+          - when: <% succeeded() %>
+            do: barrier_task
 
       parallel_task_2:
-        # ...
         # Eventually run barrier_task
+        action: core.noop
         next:
-          - do:
-              - intermediate_task
+          - when: <% succeeded() %>
+            do: intermediate_task
 
       intermediate_task:
-        # ...
         # Wait to run barrier_task after this
+        action: core.noop
         next:
-          - do:
-              - barrier_task
+          - when: <% succeeded() %>
+            do: barrier_task
 
       barrier_task:
-        # ...
         # Run after parallel_task_1, parallel_task_2, and intermediate_task have all finished
         join: all
+        action: core.noop
 
       parallel_task_3:
-        # ...
         # Run immediately after setup_task, do NOT wait for barrier_task
+        action: core.noop
 
 The following is the corresponding workflow execution graph.
 
@@ -237,6 +236,12 @@ is satisfied.
             do: barrier_task
 
       parallel_task_2:
+        action: core.noop
+        next:
+          - when: <% succeeded() %>
+            do: barrier_task
+
+      parallel_task_3:
         action: core.noop
         next:
           - when: <% succeeded() %>

--- a/docs/source/languages/orquesta.rst
+++ b/docs/source/languages/orquesta.rst
@@ -259,14 +259,13 @@ The following is the corresponding workflow execution graph.
 
     setup_task --+
                  |
-                 +-- parallel_task_1 * * * * * *
-                 |                             *
-                 +-- parallel_task_2 * * * *   *
-                 |                         *   *
-                 +-- parallel_task_3 * *   *   *
-                                       *   *   *
-                                       *   *   *
-                                       * * barrier_task (only requires 2 of 3 tasks) --+
+                 +-- parallel_task_1 --*
+                 |                     *
+                 +-- parallel_task_2 --*
+                 |                     *
+                 +-- parallel_task_3 --*
+                                       *
+                                       *-- barrier_task (only requires 2 of 3 tasks) --+
                                                                                        |
                                                                                        +-- [finish]
 

--- a/docs/source/languages/orquesta.rst
+++ b/docs/source/languages/orquesta.rst
@@ -214,8 +214,8 @@ transitioned into the join is greater than or equal to the value specified. Take
 workflow definition below, which is a revised version of the workflow from previous example.
 There are three tasks that run in parallel and will join at the barrier task. The join has a
 value of 2 which means the join will be satisfied when two out of the three parallel tasks
-complete and transition into the join task. The join will immediately run when the criteria
-is satisfied.
+complete and transition into the join. The ``barrier_task`` will immediately run when the
+join criteria is satisfied.
 
 .. code-block:: yaml
 

--- a/docs/source/schemas/mistral.json
+++ b/docs/source/schemas/mistral.json
@@ -1,938 +1,938 @@
 {
-    "type": "object",
+    "additionalProperties": false, 
+    "required": [
+        "tasks"
+    ], 
+    "type": "object", 
     "properties": {
-        "type": {
-            "enum": [
-                "reverse",
-                "direct"
-            ]
-        },
-        "vars": {
-            "type": "object",
-            "minProperties": 1,
-            "patternProperties": {
-                "^\\w+$": {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        },
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                }
-            }
-        },
-        "input": {
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {
-                        "type": "string",
-                        "minLength": 1
-                    },
-                    {
-                        "type": "object",
-                        "minProperties": 1,
-                        "maxProperties": 1,
-                        "patternProperties": {
-                            "^\\w+$": {
-                                "anyOf": [
-                                    {
-                                        "type": "null"
-                                    },
-                                    {
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "boolean"
-                                    },
-                                    {
-                                        "type": "integer"
-                                    },
-                                    {
-                                        "type": "number"
-                                    },
-                                    {
-                                        "type": "object"
-                                    },
-                                    {
-                                        "type": "string"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            "uniqueItems": true,
-            "minItems": 1
-        },
-        "output": {
-            "type": "object",
-            "minProperties": 1,
-            "patternProperties": {
-                "^\\w+$": {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        },
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                }
-            }
-        },
-        "output-on-error": {
-            "type": "object",
-            "minProperties": 1,
-            "patternProperties": {
-                "^\\w+$": {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        },
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                }
-            }
-        },
-        "task-defaults": {
-            "type": "object",
-            "properties": {
-                "concurrency": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "integer",
-                            "minimum": 0
-                        }
-                    ]
-                },
-                "keep-result": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "boolean"
-                        }
-                    ]
-                },
-                "retry": {
-                    "type": "object",
-                    "properties": {
-                        "count": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "integer",
-                                    "minimum": 0
-                                }
-                            ]
-                        },
-                        "break-on": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "continue-on": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "delay": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "integer",
-                                    "minimum": 0
-                                }
-                            ]
-                        }
-                    },
-                    "required": [
-                        "delay",
-                        "count"
-                    ],
-                    "additionalProperties": false
-                },
-                "safe-rerun": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "boolean"
-                        }
-                    ]
-                },
-                "wait-before": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "integer",
-                            "minimum": 0
-                        }
-                    ]
-                },
-                "wait-after": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "integer",
-                            "minimum": 0
-                        }
-                    ]
-                },
-                "pause-before": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "boolean"
-                        }
-                    ]
-                },
-                "target": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "timeout": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "integer",
-                            "minimum": 0
-                        }
-                    ]
-                },
-                "on-complete": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "array",
-                            "items": {
-                                "oneOf": [
-                                    {
-                                        "type": "string",
-                                        "minLength": 1
-                                    },
-                                    {
-                                        "type": "object",
-                                        "minProperties": 1,
-                                        "maxProperties": 1,
-                                        "patternProperties": {
-                                            "^\\w+$": {
-                                                "anyOf": [
-                                                    {
-                                                        "type": "null"
-                                                    },
-                                                    {
-                                                        "type": "array"
-                                                    },
-                                                    {
-                                                        "type": "boolean"
-                                                    },
-                                                    {
-                                                        "type": "integer"
-                                                    },
-                                                    {
-                                                        "type": "number"
-                                                    },
-                                                    {
-                                                        "type": "object"
-                                                    },
-                                                    {
-                                                        "type": "string"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "uniqueItems": true,
-                            "minItems": 1
-                        }
-                    ]
-                },
-                "on-success": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "array",
-                            "items": {
-                                "oneOf": [
-                                    {
-                                        "type": "string",
-                                        "minLength": 1
-                                    },
-                                    {
-                                        "type": "object",
-                                        "minProperties": 1,
-                                        "maxProperties": 1,
-                                        "patternProperties": {
-                                            "^\\w+$": {
-                                                "anyOf": [
-                                                    {
-                                                        "type": "null"
-                                                    },
-                                                    {
-                                                        "type": "array"
-                                                    },
-                                                    {
-                                                        "type": "boolean"
-                                                    },
-                                                    {
-                                                        "type": "integer"
-                                                    },
-                                                    {
-                                                        "type": "number"
-                                                    },
-                                                    {
-                                                        "type": "object"
-                                                    },
-                                                    {
-                                                        "type": "string"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "uniqueItems": true,
-                            "minItems": 1
-                        }
-                    ]
-                },
-                "on-error": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "array",
-                            "items": {
-                                "oneOf": [
-                                    {
-                                        "type": "string",
-                                        "minLength": 1
-                                    },
-                                    {
-                                        "type": "object",
-                                        "minProperties": 1,
-                                        "maxProperties": 1,
-                                        "patternProperties": {
-                                            "^\\w+$": {
-                                                "anyOf": [
-                                                    {
-                                                        "type": "null"
-                                                    },
-                                                    {
-                                                        "type": "array"
-                                                    },
-                                                    {
-                                                        "type": "boolean"
-                                                    },
-                                                    {
-                                                        "type": "integer"
-                                                    },
-                                                    {
-                                                        "type": "number"
-                                                    },
-                                                    {
-                                                        "type": "object"
-                                                    },
-                                                    {
-                                                        "type": "string"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "uniqueItems": true,
-                            "minItems": 1
-                        }
-                    ]
-                }
-            },
-            "additionalProperties": false
-        },
         "tasks": {
-            "type": "object",
-            "minProperties": 1,
+            "type": "object", 
             "patternProperties": {
                 "^\\w+$": {
-                    "type": "object",
+                    "additionalProperties": false, 
+                    "type": "object", 
+                    "anyOf": [
+                        {
+                            "not": {
+                                "required": [
+                                    "action", 
+                                    "workflow"
+                                ], 
+                                "type": "object"
+                            }
+                        }, 
+                        {
+                            "oneOf": [
+                                {
+                                    "required": [
+                                        "action"
+                                    ], 
+                                    "type": "object"
+                                }, 
+                                {
+                                    "required": [
+                                        "workflow"
+                                    ], 
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ], 
                     "properties": {
+                        "with-items": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "uniqueItems": true, 
+                                    "items": {
+                                        "minLength": 1, 
+                                        "type": "string"
+                                    }, 
+                                    "type": "array", 
+                                    "minItems": 1
+                                }
+                            ]
+                        }, 
+                        "retry": {
+                            "additionalProperties": false, 
+                            "required": [
+                                "delay", 
+                                "count"
+                            ], 
+                            "type": "object", 
+                            "properties": {
+                                "count": {
+                                    "oneOf": [
+                                        {
+                                            "minLength": 1, 
+                                            "type": "string"
+                                        }, 
+                                        {
+                                            "minimum": 0, 
+                                            "type": "integer"
+                                        }
+                                    ]
+                                }, 
+                                "delay": {
+                                    "oneOf": [
+                                        {
+                                            "minLength": 1, 
+                                            "type": "string"
+                                        }, 
+                                        {
+                                            "minimum": 0, 
+                                            "type": "integer"
+                                        }
+                                    ]
+                                }, 
+                                "continue-on": {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                "break-on": {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }
+                            }
+                        }, 
                         "join": {
                             "oneOf": [
                                 {
                                     "enum": [
                                         "all"
                                     ]
-                                },
+                                }, 
                                 {
-                                    "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0, 
+                                    "type": "integer"
                                 }
                             ]
-                        },
-                        "with-items": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "minLength": 1
-                                    },
-                                    "uniqueItems": true,
-                                    "minItems": 1
-                                }
-                            ]
-                        },
-                        "concurrency": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "integer",
-                                    "minimum": 0
-                                }
-                            ]
-                        },
-                        "action": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "workflow": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "input": {
-                            "type": "object",
-                            "minProperties": 1,
-                            "patternProperties": {
-                                "^\\w+$": {
-                                    "anyOf": [
-                                        {
-                                            "type": "null"
-                                        },
-                                        {
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": "boolean"
-                                        },
-                                        {
-                                            "type": "integer"
-                                        },
-                                        {
-                                            "type": "number"
-                                        },
-                                        {
-                                            "type": "object"
-                                        },
-                                        {
-                                            "type": "string"
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "publish": {
-                            "type": "object",
-                            "minProperties": 1,
-                            "patternProperties": {
-                                "^\\w+$": {
-                                    "anyOf": [
-                                        {
-                                            "type": "null"
-                                        },
-                                        {
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": "boolean"
-                                        },
-                                        {
-                                            "type": "integer"
-                                        },
-                                        {
-                                            "type": "number"
-                                        },
-                                        {
-                                            "type": "object"
-                                        },
-                                        {
-                                            "type": "string"
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "publish-on-error": {
-                            "type": "object",
-                            "minProperties": 1,
-                            "patternProperties": {
-                                "^\\w+$": {
-                                    "anyOf": [
-                                        {
-                                            "type": "null"
-                                        },
-                                        {
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": "boolean"
-                                        },
-                                        {
-                                            "type": "integer"
-                                        },
-                                        {
-                                            "type": "number"
-                                        },
-                                        {
-                                            "type": "object"
-                                        },
-                                        {
-                                            "type": "string"
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "keep-result": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "boolean"
-                                }
-                            ]
-                        },
-                        "retry": {
-                            "type": "object",
-                            "properties": {
-                                "count": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string",
-                                            "minLength": 1
-                                        },
-                                        {
-                                            "type": "integer",
-                                            "minimum": 0
-                                        }
-                                    ]
-                                },
-                                "break-on": {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                "continue-on": {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                "delay": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string",
-                                            "minLength": 1
-                                        },
-                                        {
-                                            "type": "integer",
-                                            "minimum": 0
-                                        }
-                                    ]
-                                }
-                            },
-                            "required": [
-                                "delay",
-                                "count"
-                            ],
-                            "additionalProperties": false
-                        },
-                        "safe-rerun": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "boolean"
-                                }
-                            ]
-                        },
-                        "wait-before": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "integer",
-                                    "minimum": 0
-                                }
-                            ]
-                        },
-                        "wait-after": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "integer",
-                                    "minimum": 0
-                                }
-                            ]
-                        },
-                        "pause-before": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "boolean"
-                                }
-                            ]
-                        },
+                        }, 
                         "target": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "timeout": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "integer",
-                                    "minimum": 0
-                                }
-                            ]
-                        },
-                        "on-complete": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "array",
-                                    "items": {
-                                        "oneOf": [
-                                            {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            {
-                                                "type": "object",
-                                                "minProperties": 1,
-                                                "maxProperties": 1,
-                                                "patternProperties": {
-                                                    "^\\w+$": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "null"
-                                                            },
-                                                            {
-                                                                "type": "array"
-                                                            },
-                                                            {
-                                                                "type": "boolean"
-                                                            },
-                                                            {
-                                                                "type": "integer"
-                                                            },
-                                                            {
-                                                                "type": "number"
-                                                            },
-                                                            {
-                                                                "type": "object"
-                                                            },
-                                                            {
-                                                                "type": "string"
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    "uniqueItems": true,
-                                    "minItems": 1
-                                }
-                            ]
-                        },
-                        "on-success": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "array",
-                                    "items": {
-                                        "oneOf": [
-                                            {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            {
-                                                "type": "object",
-                                                "minProperties": 1,
-                                                "maxProperties": 1,
-                                                "patternProperties": {
-                                                    "^\\w+$": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "null"
-                                                            },
-                                                            {
-                                                                "type": "array"
-                                                            },
-                                                            {
-                                                                "type": "boolean"
-                                                            },
-                                                            {
-                                                                "type": "integer"
-                                                            },
-                                                            {
-                                                                "type": "number"
-                                                            },
-                                                            {
-                                                                "type": "object"
-                                                            },
-                                                            {
-                                                                "type": "string"
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    "uniqueItems": true,
-                                    "minItems": 1
-                                }
-                            ]
-                        },
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
                         "on-error": {
                             "oneOf": [
                                 {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
                                 {
-                                    "type": "array",
+                                    "uniqueItems": true, 
                                     "items": {
                                         "oneOf": [
                                             {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
+                                                "minLength": 1, 
+                                                "type": "string"
+                                            }, 
                                             {
-                                                "type": "object",
-                                                "minProperties": 1,
-                                                "maxProperties": 1,
                                                 "patternProperties": {
                                                     "^\\w+$": {
                                                         "anyOf": [
                                                             {
                                                                 "type": "null"
-                                                            },
+                                                            }, 
                                                             {
                                                                 "type": "array"
-                                                            },
+                                                            }, 
                                                             {
                                                                 "type": "boolean"
-                                                            },
+                                                            }, 
                                                             {
                                                                 "type": "integer"
-                                                            },
+                                                            }, 
                                                             {
                                                                 "type": "number"
-                                                            },
+                                                            }, 
                                                             {
                                                                 "type": "object"
-                                                            },
+                                                            }, 
                                                             {
                                                                 "type": "string"
                                                             }
                                                         ]
                                                     }
-                                                }
+                                                }, 
+                                                "maxProperties": 1, 
+                                                "minProperties": 1, 
+                                                "type": "object"
                                             }
                                         ]
-                                    },
-                                    "uniqueItems": true,
+                                    }, 
+                                    "type": "array", 
                                     "minItems": 1
                                 }
                             ]
-                        }
-                    },
-                    "additionalProperties": false,
-                    "anyOf": [
-                        {
-                            "not": {
-                                "type": "object",
-                                "required": [
-                                    "action",
-                                    "workflow"
-                                ]
-                            }
-                        },
-                        {
+                        }, 
+                        "workflow": {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        "concurrency": {
                             "oneOf": [
                                 {
-                                    "type": "object",
-                                    "required": [
-                                        "action"
-                                    ]
-                                },
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
                                 {
-                                    "type": "object",
-                                    "required": [
-                                        "workflow"
-                                    ]
+                                    "minimum": 0, 
+                                    "type": "integer"
                                 }
                             ]
+                        }, 
+                        "on-success": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "uniqueItems": true, 
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "minLength": 1, 
+                                                "type": "string"
+                                            }, 
+                                            {
+                                                "patternProperties": {
+                                                    "^\\w+$": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "null"
+                                                            }, 
+                                                            {
+                                                                "type": "array"
+                                                            }, 
+                                                            {
+                                                                "type": "boolean"
+                                                            }, 
+                                                            {
+                                                                "type": "integer"
+                                                            }, 
+                                                            {
+                                                                "type": "number"
+                                                            }, 
+                                                            {
+                                                                "type": "object"
+                                                            }, 
+                                                            {
+                                                                "type": "string"
+                                                            }
+                                                        ]
+                                                    }
+                                                }, 
+                                                "maxProperties": 1, 
+                                                "minProperties": 1, 
+                                                "type": "object"
+                                            }
+                                        ]
+                                    }, 
+                                    "type": "array", 
+                                    "minItems": 1
+                                }
+                            ]
+                        }, 
+                        "publish-on-error": {
+                            "type": "object", 
+                            "patternProperties": {
+                                "^\\w+$": {
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        }, 
+                                        {
+                                            "type": "array"
+                                        }, 
+                                        {
+                                            "type": "boolean"
+                                        }, 
+                                        {
+                                            "type": "integer"
+                                        }, 
+                                        {
+                                            "type": "number"
+                                        }, 
+                                        {
+                                            "type": "object"
+                                        }, 
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                }
+                            }, 
+                            "minProperties": 1
+                        }, 
+                        "publish": {
+                            "type": "object", 
+                            "patternProperties": {
+                                "^\\w+$": {
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        }, 
+                                        {
+                                            "type": "array"
+                                        }, 
+                                        {
+                                            "type": "boolean"
+                                        }, 
+                                        {
+                                            "type": "integer"
+                                        }, 
+                                        {
+                                            "type": "number"
+                                        }, 
+                                        {
+                                            "type": "object"
+                                        }, 
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                }
+                            }, 
+                            "minProperties": 1
+                        }, 
+                        "wait-after": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "minimum": 0, 
+                                    "type": "integer"
+                                }
+                            ]
+                        }, 
+                        "action": {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        "keep-result": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        }, 
+                        "wait-before": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "minimum": 0, 
+                                    "type": "integer"
+                                }
+                            ]
+                        }, 
+                        "timeout": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "minimum": 0, 
+                                    "type": "integer"
+                                }
+                            ]
+                        }, 
+                        "safe-rerun": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        }, 
+                        "input": {
+                            "type": "object", 
+                            "patternProperties": {
+                                "^\\w+$": {
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        }, 
+                                        {
+                                            "type": "array"
+                                        }, 
+                                        {
+                                            "type": "boolean"
+                                        }, 
+                                        {
+                                            "type": "integer"
+                                        }, 
+                                        {
+                                            "type": "number"
+                                        }, 
+                                        {
+                                            "type": "object"
+                                        }, 
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                }
+                            }, 
+                            "minProperties": 1
+                        }, 
+                        "on-complete": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "uniqueItems": true, 
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "minLength": 1, 
+                                                "type": "string"
+                                            }, 
+                                            {
+                                                "patternProperties": {
+                                                    "^\\w+$": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "null"
+                                                            }, 
+                                                            {
+                                                                "type": "array"
+                                                            }, 
+                                                            {
+                                                                "type": "boolean"
+                                                            }, 
+                                                            {
+                                                                "type": "integer"
+                                                            }, 
+                                                            {
+                                                                "type": "number"
+                                                            }, 
+                                                            {
+                                                                "type": "object"
+                                                            }, 
+                                                            {
+                                                                "type": "string"
+                                                            }
+                                                        ]
+                                                    }
+                                                }, 
+                                                "maxProperties": 1, 
+                                                "minProperties": 1, 
+                                                "type": "object"
+                                            }
+                                        ]
+                                    }, 
+                                    "type": "array", 
+                                    "minItems": 1
+                                }
+                            ]
+                        }, 
+                        "pause-before": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }, 
+            "minProperties": 1
+        }, 
+        "description": {
+            "minLength": 1, 
+            "type": "string"
+        }, 
+        "vars": {
+            "patternProperties": {
+                "^\\w+$": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, 
+                        {
+                            "type": "array"
+                        }, 
+                        {
+                            "type": "boolean"
+                        }, 
+                        {
+                            "type": "integer"
+                        }, 
+                        {
+                            "type": "number"
+                        }, 
+                        {
+                            "type": "object"
+                        }, 
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            }, 
+            "type": "object", 
+            "minProperties": 1
+        }, 
+        "tags": {
+            "uniqueItems": true, 
+            "items": {
+                "minLength": 1, 
+                "type": "string"
+            }, 
+            "type": "array", 
+            "minItems": 1
+        }, 
+        "task-defaults": {
+            "additionalProperties": false, 
+            "type": "object", 
+            "properties": {
+                "retry": {
+                    "additionalProperties": false, 
+                    "required": [
+                        "delay", 
+                        "count"
+                    ], 
+                    "type": "object", 
+                    "properties": {
+                        "count": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "minimum": 0, 
+                                    "type": "integer"
+                                }
+                            ]
+                        }, 
+                        "delay": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "minimum": 0, 
+                                    "type": "integer"
+                                }
+                            ]
+                        }, 
+                        "continue-on": {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        "break-on": {
+                            "minLength": 1, 
+                            "type": "string"
+                        }
+                    }
+                }, 
+                "target": {
+                    "minLength": 1, 
+                    "type": "string"
+                }, 
+                "on-error": {
+                    "oneOf": [
+                        {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        {
+                            "uniqueItems": true, 
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "minLength": 1, 
+                                        "type": "string"
+                                    }, 
+                                    {
+                                        "patternProperties": {
+                                            "^\\w+$": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    }, 
+                                                    {
+                                                        "type": "array"
+                                                    }, 
+                                                    {
+                                                        "type": "boolean"
+                                                    }, 
+                                                    {
+                                                        "type": "integer"
+                                                    }, 
+                                                    {
+                                                        "type": "number"
+                                                    }, 
+                                                    {
+                                                        "type": "object"
+                                                    }, 
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            }
+                                        }, 
+                                        "maxProperties": 1, 
+                                        "minProperties": 1, 
+                                        "type": "object"
+                                    }
+                                ]
+                            }, 
+                            "type": "array", 
+                            "minItems": 1
+                        }
+                    ]
+                }, 
+                "on-success": {
+                    "oneOf": [
+                        {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        {
+                            "uniqueItems": true, 
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "minLength": 1, 
+                                        "type": "string"
+                                    }, 
+                                    {
+                                        "patternProperties": {
+                                            "^\\w+$": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    }, 
+                                                    {
+                                                        "type": "array"
+                                                    }, 
+                                                    {
+                                                        "type": "boolean"
+                                                    }, 
+                                                    {
+                                                        "type": "integer"
+                                                    }, 
+                                                    {
+                                                        "type": "number"
+                                                    }, 
+                                                    {
+                                                        "type": "object"
+                                                    }, 
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            }
+                                        }, 
+                                        "maxProperties": 1, 
+                                        "minProperties": 1, 
+                                        "type": "object"
+                                    }
+                                ]
+                            }, 
+                            "type": "array", 
+                            "minItems": 1
+                        }
+                    ]
+                }, 
+                "timeout": {
+                    "oneOf": [
+                        {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        {
+                            "minimum": 0, 
+                            "type": "integer"
+                        }
+                    ]
+                }, 
+                "wait-after": {
+                    "oneOf": [
+                        {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        {
+                            "minimum": 0, 
+                            "type": "integer"
+                        }
+                    ]
+                }, 
+                "keep-result": {
+                    "oneOf": [
+                        {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        {
+                            "type": "boolean"
+                        }
+                    ]
+                }, 
+                "pause-before": {
+                    "oneOf": [
+                        {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        {
+                            "type": "boolean"
+                        }
+                    ]
+                }, 
+                "concurrency": {
+                    "oneOf": [
+                        {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        {
+                            "minimum": 0, 
+                            "type": "integer"
+                        }
+                    ]
+                }, 
+                "safe-rerun": {
+                    "oneOf": [
+                        {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        {
+                            "type": "boolean"
+                        }
+                    ]
+                }, 
+                "on-complete": {
+                    "oneOf": [
+                        {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        {
+                            "uniqueItems": true, 
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "minLength": 1, 
+                                        "type": "string"
+                                    }, 
+                                    {
+                                        "patternProperties": {
+                                            "^\\w+$": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    }, 
+                                                    {
+                                                        "type": "array"
+                                                    }, 
+                                                    {
+                                                        "type": "boolean"
+                                                    }, 
+                                                    {
+                                                        "type": "integer"
+                                                    }, 
+                                                    {
+                                                        "type": "number"
+                                                    }, 
+                                                    {
+                                                        "type": "object"
+                                                    }, 
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            }
+                                        }, 
+                                        "maxProperties": 1, 
+                                        "minProperties": 1, 
+                                        "type": "object"
+                                    }
+                                ]
+                            }, 
+                            "type": "array", 
+                            "minItems": 1
+                        }
+                    ]
+                }, 
+                "wait-before": {
+                    "oneOf": [
+                        {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        {
+                            "minimum": 0, 
+                            "type": "integer"
                         }
                     ]
                 }
             }
-        },
-        "name": {
-            "type": "string",
-            "minLength": 1
-        },
+        }, 
+        "output-on-error": {
+            "patternProperties": {
+                "^\\w+$": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, 
+                        {
+                            "type": "array"
+                        }, 
+                        {
+                            "type": "boolean"
+                        }, 
+                        {
+                            "type": "integer"
+                        }, 
+                        {
+                            "type": "number"
+                        }, 
+                        {
+                            "type": "object"
+                        }, 
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            }, 
+            "type": "object", 
+            "minProperties": 1
+        }, 
         "version": {
+            "enum": [
+                "2.0", 
+                2.0
+            ], 
             "anyOf": [
                 {
-                    "type": "string",
-                    "minLength": 1
-                },
+                    "minLength": 1, 
+                    "type": "string"
+                }, 
                 {
-                    "type": "integer",
-                    "minimum": 0
-                },
+                    "minimum": 0, 
+                    "type": "integer"
+                }, 
                 {
-                    "type": "number",
-                    "minimum": 0.0
+                    "minimum": 0.0, 
+                    "type": "number"
                 }
-            ],
-            "enum": [
-                "2.0",
-                2.0
             ]
-        },
-        "description": {
-            "type": "string",
-            "minLength": 1
-        },
-        "tags": {
-            "type": "array",
+        }, 
+        "output": {
+            "patternProperties": {
+                "^\\w+$": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, 
+                        {
+                            "type": "array"
+                        }, 
+                        {
+                            "type": "boolean"
+                        }, 
+                        {
+                            "type": "integer"
+                        }, 
+                        {
+                            "type": "number"
+                        }, 
+                        {
+                            "type": "object"
+                        }, 
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            }, 
+            "type": "object", 
+            "minProperties": 1
+        }, 
+        "input": {
+            "uniqueItems": true, 
             "items": {
-                "type": "string",
-                "minLength": 1
-            },
-            "uniqueItems": true,
+                "oneOf": [
+                    {
+                        "minLength": 1, 
+                        "type": "string"
+                    }, 
+                    {
+                        "maxProperties": 1, 
+                        "patternProperties": {
+                            "^\\w+$": {
+                                "anyOf": [
+                                    {
+                                        "type": "null"
+                                    }, 
+                                    {
+                                        "type": "array"
+                                    }, 
+                                    {
+                                        "type": "boolean"
+                                    }, 
+                                    {
+                                        "type": "integer"
+                                    }, 
+                                    {
+                                        "type": "number"
+                                    }, 
+                                    {
+                                        "type": "object"
+                                    }, 
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        }, 
+                        "minProperties": 1, 
+                        "type": "object"
+                    }
+                ]
+            }, 
+            "type": "array", 
             "minItems": 1
+        }, 
+        "type": {
+            "enum": [
+                "reverse", 
+                "direct"
+            ]
+        }, 
+        "name": {
+            "minLength": 1, 
+            "type": "string"
         }
-    },
-    "required": [
-        "tasks"
-    ],
-    "additionalProperties": false
+    }
 }

--- a/docs/source/schemas/orquesta.json
+++ b/docs/source/schemas/orquesta.json
@@ -1,379 +1,379 @@
 {
-    "type": "object",
+    "additionalProperties": false, 
+    "required": [
+        "tasks"
+    ], 
+    "type": "object", 
     "properties": {
-        "vars": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "minProperties": 1,
-                "maxProperties": 1,
-                "patternProperties": {
-                    "^\\w+$": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "type": "array"
-                            },
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "object"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ]
-                    }
-                }
-            },
-            "uniqueItems": true,
-            "minItems": 1
-        },
-        "input": {
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {
-                        "type": "string",
-                        "minLength": 1
-                    },
-                    {
-                        "type": "object",
-                        "minProperties": 1,
-                        "maxProperties": 1,
-                        "patternProperties": {
-                            "^\\w+$": {
-                                "anyOf": [
-                                    {
-                                        "type": "null"
-                                    },
-                                    {
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "boolean"
-                                    },
-                                    {
-                                        "type": "integer"
-                                    },
-                                    {
-                                        "type": "number"
-                                    },
-                                    {
-                                        "type": "object"
-                                    },
-                                    {
-                                        "type": "string"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            "uniqueItems": true,
-            "minItems": 1
-        },
-        "output": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "minProperties": 1,
-                "maxProperties": 1,
-                "patternProperties": {
-                    "^\\w+$": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "type": "array"
-                            },
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "object"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ]
-                    }
-                }
-            },
-            "uniqueItems": true,
-            "minItems": 1
-        },
         "tasks": {
-            "type": "object",
-            "minProperties": 1,
+            "type": "object", 
             "patternProperties": {
                 "^\\w+$": {
-                    "type": "object",
+                    "additionalProperties": false, 
+                    "type": "object", 
                     "properties": {
-                        "delay": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "integer",
-                                    "minimum": 0
+                        "retry": {
+                            "additionalProperties": false, 
+                            "required": [
+                                "count"
+                            ], 
+                            "type": "object", 
+                            "properties": {
+                                "count": {
+                                    "oneOf": [
+                                        {
+                                            "minLength": 1, 
+                                            "type": "string"
+                                        }, 
+                                        {
+                                            "minimum": 0, 
+                                            "type": "integer"
+                                        }
+                                    ]
+                                }, 
+                                "delay": {
+                                    "oneOf": [
+                                        {
+                                            "minLength": 1, 
+                                            "type": "string"
+                                        }, 
+                                        {
+                                            "minimum": 0, 
+                                            "type": "integer"
+                                        }
+                                    ]
+                                }, 
+                                "when": {
+                                    "minLength": 1, 
+                                    "type": "string"
                                 }
-                            ]
-                        },
+                            }
+                        }, 
                         "join": {
                             "oneOf": [
                                 {
                                     "enum": [
                                         "all"
                                     ]
-                                },
+                                }, 
                                 {
-                                    "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0, 
+                                    "type": "integer"
                                 }
                             ]
-                        },
-                        "with": {
-                            "type": "object",
-                            "properties": {
-                                "items": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "pattern": "^(\\s+)?({{.*?}}|<%.*?%>)(\\s+)?$|^(\\s+)?((\\w+,\\s?|\\s+)+)?(\\w+)\\s+in\\s+({{.*?}}|<%.*?%>)(\\s+)?$"
-                                },
-                                "concurrency": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string",
-                                            "minLength": 1
-                                        },
-                                        {
-                                            "type": "integer",
-                                            "minimum": 0
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "action": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "input": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                {
-                                    "type": "object",
-                                    "minProperties": 1,
-                                    "patternProperties": {
-                                        "^\\w+$": {
-                                            "anyOf": [
-                                                {
-                                                    "type": "null"
-                                                },
-                                                {
-                                                    "type": "array"
-                                                },
-                                                {
-                                                    "type": "boolean"
-                                                },
-                                                {
-                                                    "type": "integer"
-                                                },
-                                                {
-                                                    "type": "number"
-                                                },
-                                                {
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "type": "string"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "retry": {
-                            "type": "object",
-                            "properties": {
-                                "when": {
-                                    "type": "string",
-                                    "minLength": 1
-                                },
-                                "count": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string",
-                                            "minLength": 1
-                                        },
-                                        {
-                                            "type": "integer",
-                                            "minimum": 0
-                                        }
-                                    ]
-                                },
-                                "delay": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string",
-                                            "minLength": 1
-                                        },
-                                        {
-                                            "type": "integer",
-                                            "minimum": 0
-                                        }
-                                    ]
-                                }
-                            },
-                            "required": [
-                                "count"
-                            ],
-                            "additionalProperties": false
-                        },
+                        }, 
                         "next": {
-                            "type": "array",
                             "items": {
-                                "type": "object",
+                                "additionalProperties": false, 
+                                "type": "object", 
                                 "properties": {
+                                    "do": {
+                                        "oneOf": [
+                                            {
+                                                "minLength": 1, 
+                                                "type": "string"
+                                            }, 
+                                            {
+                                                "uniqueItems": true, 
+                                                "items": {
+                                                    "minLength": 1, 
+                                                    "type": "string"
+                                                }, 
+                                                "type": "array", 
+                                                "minItems": 1
+                                            }
+                                        ]
+                                    }, 
                                     "when": {
-                                        "type": "string",
-                                        "minLength": 1
-                                    },
+                                        "minLength": 1, 
+                                        "type": "string"
+                                    }, 
                                     "publish": {
                                         "oneOf": [
                                             {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
+                                                "minLength": 1, 
+                                                "type": "string"
+                                            }, 
                                             {
-                                                "type": "array",
+                                                "uniqueItems": true, 
                                                 "items": {
-                                                    "type": "object",
-                                                    "minProperties": 1,
-                                                    "maxProperties": 1,
                                                     "patternProperties": {
                                                         "^\\w+$": {
                                                             "anyOf": [
                                                                 {
                                                                     "type": "null"
-                                                                },
+                                                                }, 
                                                                 {
                                                                     "type": "array"
-                                                                },
+                                                                }, 
                                                                 {
                                                                     "type": "boolean"
-                                                                },
+                                                                }, 
                                                                 {
                                                                     "type": "integer"
-                                                                },
+                                                                }, 
                                                                 {
                                                                     "type": "number"
-                                                                },
+                                                                }, 
                                                                 {
                                                                     "type": "object"
-                                                                },
+                                                                }, 
                                                                 {
                                                                     "type": "string"
                                                                 }
                                                             ]
                                                         }
-                                                    }
-                                                },
-                                                "uniqueItems": true,
-                                                "minItems": 1
-                                            }
-                                        ]
-                                    },
-                                    "do": {
-                                        "oneOf": [
-                                            {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string",
-                                                    "minLength": 1
-                                                },
-                                                "uniqueItems": true,
+                                                    }, 
+                                                    "maxProperties": 1, 
+                                                    "minProperties": 1, 
+                                                    "type": "object"
+                                                }, 
+                                                "type": "array", 
                                                 "minItems": 1
                                             }
                                         ]
                                     }
-                                },
-                                "additionalProperties": false
+                                }
+                            }, 
+                            "type": "array"
+                        }, 
+                        "delay": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "minimum": 0, 
+                                    "type": "integer"
+                                }
+                            ]
+                        }, 
+                        "action": {
+                            "minLength": 1, 
+                            "type": "string"
+                        }, 
+                        "input": {
+                            "oneOf": [
+                                {
+                                    "minLength": 1, 
+                                    "type": "string"
+                                }, 
+                                {
+                                    "type": "object", 
+                                    "patternProperties": {
+                                        "^\\w+$": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "null"
+                                                }, 
+                                                {
+                                                    "type": "array"
+                                                }, 
+                                                {
+                                                    "type": "boolean"
+                                                }, 
+                                                {
+                                                    "type": "integer"
+                                                }, 
+                                                {
+                                                    "type": "number"
+                                                }, 
+                                                {
+                                                    "type": "object"
+                                                }, 
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ]
+                                        }
+                                    }, 
+                                    "minProperties": 1
+                                }
+                            ]
+                        }, 
+                        "with": {
+                            "type": "object", 
+                            "properties": {
+                                "items": {
+                                    "minLength": 1, 
+                                    "type": "string", 
+                                    "pattern": "^(\\s+)?({{.*?}}|<%.*?%>)(\\s+)?$|^(\\s+)?((\\w+,\\s?|\\s+)+)?(\\w+)\\s+in\\s+({{.*?}}|<%.*?%>)(\\s+)?$"
+                                }, 
+                                "concurrency": {
+                                    "oneOf": [
+                                        {
+                                            "minLength": 1, 
+                                            "type": "string"
+                                        }, 
+                                        {
+                                            "minimum": 0, 
+                                            "type": "integer"
+                                        }
+                                    ]
+                                }
                             }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 }
-            }
-        },
-        "name": {
-            "type": "string",
-            "minLength": 1
-        },
+            }, 
+            "minProperties": 1
+        }, 
+        "description": {
+            "minLength": 1, 
+            "type": "string"
+        }, 
+        "vars": {
+            "uniqueItems": true, 
+            "items": {
+                "maxProperties": 1, 
+                "patternProperties": {
+                    "^\\w+$": {
+                        "anyOf": [
+                            {
+                                "type": "null"
+                            }, 
+                            {
+                                "type": "array"
+                            }, 
+                            {
+                                "type": "boolean"
+                            }, 
+                            {
+                                "type": "integer"
+                            }, 
+                            {
+                                "type": "number"
+                            }, 
+                            {
+                                "type": "object"
+                            }, 
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }, 
+                "minProperties": 1, 
+                "type": "object"
+            }, 
+            "type": "array", 
+            "minItems": 1
+        }, 
+        "tags": {
+            "uniqueItems": true, 
+            "items": {
+                "minLength": 1, 
+                "type": "string"
+            }, 
+            "type": "array", 
+            "minItems": 1
+        }, 
         "version": {
+            "enum": [
+                "1.0", 
+                1.0
+            ], 
             "anyOf": [
                 {
-                    "type": "string",
-                    "minLength": 1
-                },
+                    "minLength": 1, 
+                    "type": "string"
+                }, 
                 {
-                    "type": "integer",
-                    "minimum": 0
-                },
+                    "minimum": 0, 
+                    "type": "integer"
+                }, 
                 {
-                    "type": "number",
-                    "minimum": 0.0
+                    "minimum": 0.0, 
+                    "type": "number"
                 }
-            ],
-            "enum": [
-                "1.0",
-                1.0
             ]
-        },
-        "description": {
-            "type": "string",
-            "minLength": 1
-        },
-        "tags": {
-            "type": "array",
+        }, 
+        "output": {
+            "uniqueItems": true, 
             "items": {
-                "type": "string",
-                "minLength": 1
-            },
-            "uniqueItems": true,
+                "maxProperties": 1, 
+                "patternProperties": {
+                    "^\\w+$": {
+                        "anyOf": [
+                            {
+                                "type": "null"
+                            }, 
+                            {
+                                "type": "array"
+                            }, 
+                            {
+                                "type": "boolean"
+                            }, 
+                            {
+                                "type": "integer"
+                            }, 
+                            {
+                                "type": "number"
+                            }, 
+                            {
+                                "type": "object"
+                            }, 
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }, 
+                "minProperties": 1, 
+                "type": "object"
+            }, 
+            "type": "array", 
             "minItems": 1
+        }, 
+        "input": {
+            "uniqueItems": true, 
+            "items": {
+                "oneOf": [
+                    {
+                        "minLength": 1, 
+                        "type": "string"
+                    }, 
+                    {
+                        "maxProperties": 1, 
+                        "patternProperties": {
+                            "^\\w+$": {
+                                "anyOf": [
+                                    {
+                                        "type": "null"
+                                    }, 
+                                    {
+                                        "type": "array"
+                                    }, 
+                                    {
+                                        "type": "boolean"
+                                    }, 
+                                    {
+                                        "type": "integer"
+                                    }, 
+                                    {
+                                        "type": "number"
+                                    }, 
+                                    {
+                                        "type": "object"
+                                    }, 
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        }, 
+                        "minProperties": 1, 
+                        "type": "object"
+                    }
+                ]
+            }, 
+            "type": "array", 
+            "minItems": 1
+        }, 
+        "name": {
+            "minLength": 1, 
+            "type": "string"
         }
-    },
-    "required": [
-        "tasks"
-    ],
-    "additionalProperties": false
+    }
 }

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -168,7 +168,7 @@ class WorkflowState(object):
         # Evaluate each task that is already staged.
         for staged_task in self.get_staged_tasks(filtered=False):
             # If the task is not a barrier or it is already ready, then it is not unreachable.
-            if staged_task['id'] not in barriers or staged_task['ready'] is True:
+            if staged_task['id'] not in barriers or bool(staged_task['ready']):
                 continue
 
             # Determine the status of the inbound criteria for the barrier task.
@@ -545,7 +545,7 @@ class WorkflowConductor(object):
                 prev_task_state_entry['next'][prev_task_transition_id]
             )
 
-            if inbound_evaluation[prev_transition[0]] is not True:
+            if not bool(inbound_evaluation[prev_transition[0]]):
                 inbound_evaluation[prev_transition[0]] = satisfied
 
         # If the count of inbound task(s) where the criteria is True >= requirements,

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -136,8 +136,12 @@ class WorkflowState(object):
             if t.get('term', False)
         ]
 
-    def has_next_tasks(self, task_id=None, route=None):
-        return self.conductor.has_next_tasks(task_id=task_id, route=route)
+    def has_next_tasks(self, task_id=None, route=None, speculate_join=False):
+        return self.conductor.has_next_tasks(
+            task_id=task_id,
+            route=route,
+            speculate_join=speculate_join
+        )
 
     @property
     def has_active_tasks(self):
@@ -590,7 +594,7 @@ class WorkflowConductor(object):
 
         return task
 
-    def has_next_tasks(self, task_id=None, route=None):
+    def has_next_tasks(self, task_id=None, route=None, speculate_join=False):
         if not task_id:
             return True if self.workflow_state.get_staged_tasks() else False
         else:
@@ -617,8 +621,9 @@ class WorkflowConductor(object):
                 if not task_state_entry['next'].get(task_transition_id):
                     continue
 
-                # Evaluate if inbound criteria for the next task is satisfied.
-                if not self._inbound_criteria_satisfied(next_task_id, route):
+                # If not speculating join task, then evaluate if inbound criteria
+                # for the next task is satisfied.
+                if not speculate_join and not self._inbound_criteria_satisfied(next_task_id, route):
                     continue
 
                 return True

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -172,7 +172,7 @@ class WorkflowState(object):
                 continue
 
             # Determine the status of the inbound criteria for the barrier task.
-            inbound_criteria_status = self.conductor.inbound_criteria_satisfied(
+            inbound_criteria_status = self.conductor.get_inbound_criteria_status(
                 staged_task['id'], staged_task['route']
             )
 
@@ -517,7 +517,7 @@ class WorkflowConductor(object):
     def reset_workflow_output(self):
         self._outputs = None
 
-    def inbound_criteria_satisfied(self, task_id, route):
+    def get_inbound_criteria_status(self, task_id, route):
         # Get the list of inbound task transitions for the barrier task.
         inbound_transitions = self.graph.get_prev_transitions(task_id)
 
@@ -665,7 +665,7 @@ class WorkflowConductor(object):
 
                 # Evaluate if inbound criteria is satisified for barrier (join) task.
                 if self.graph.has_barrier(next_task_id):
-                    inbound_criteria_status = self.inbound_criteria_satisfied(next_task_id, route)
+                    inbound_criteria_status = self.get_inbound_criteria_status(next_task_id, route)
                     if inbound_criteria_status == constants.INBOUND_CRITERIA_NOT_SATISFIED:
                         continue
 
@@ -1030,7 +1030,7 @@ class WorkflowConductor(object):
                     # Check if inbound criteria are met. Must use the original route
                     # to identify the inbound task transitions.
                     staged_next_task['ready'] = (
-                        self.inbound_criteria_satisfied(next_task_id, route) ==
+                        self.get_inbound_criteria_status(next_task_id, route) ==
                         constants.INBOUND_CRITERIA_SATISFIED
                     )
 

--- a/orquesta/conducting.py
+++ b/orquesta/conducting.py
@@ -553,9 +553,12 @@ class WorkflowConductor(object):
         if list(inbound_evaluation.values()).count(True) >= requirement:
             return constants.INBOUND_CRITERIA_SATISFIED
 
-        # If there is an inbound task(s) where the criteria is None,
-        # then this means not all inbound task(s) have run.
-        if None in inbound_evaluation.values():
+        # If there is an inbound task(s) where the criteria is None and there is still
+        # active task(s) or staged task(s) that is ready,  then this means that the
+        # workflow is still active and it is possible that not all inbound branch(es)
+        # and subsequent task(s) have run.
+        if (None in inbound_evaluation.values() and
+                (self.workflow_state.has_active_tasks or self.workflow_state.has_staged_tasks)):
             return constants.INBOUND_CRITERIA_WIP
 
         # If reached here, then the requirement is not satisified.

--- a/orquesta/constants.py
+++ b/orquesta/constants.py
@@ -14,3 +14,7 @@
 
 TASK_STATE_ROUTE_FORMAT = '%s__r%s'
 TASK_STATE_TRANSITION_FORMAT = '%s__t%s'
+
+INBOUND_CRITERIA_WIP = 'inbound_criteria_wip'
+INBOUND_CRITERIA_SATISFIED = 'inbound_criteria_satisfied'
+INBOUND_CRITERIA_NOT_SATISFIED = 'inbound_criteria_not_satisfied'

--- a/orquesta/exceptions.py
+++ b/orquesta/exceptions.py
@@ -155,3 +155,10 @@ class InvalidTaskRerunRequest(Exception):
 
         message = "Unable to rerun task|route(s) because it doesn't exist or isn't rerunnable: %s"
         super(InvalidTaskRerunRequest, self).__init__(message % tasks_str)
+
+
+class UnreachableJoinError(Exception):
+
+    def __init__(self, task_id, route):
+        message = 'The join task|route "%s|%s" is partially satisfied but unreachable.'
+        super(UnreachableJoinError, self).__init__(message % (task_id, route))

--- a/orquesta/graphing.py
+++ b/orquesta/graphing.py
@@ -178,6 +178,11 @@ class WorkflowGraph(object):
             key=lambda x: x[1]
         )
 
+    def get_barriers(self):
+        return {
+            x[0]: x[1] for x in filter(lambda x: x[1].get('barrier'), self._graph.nodes(data=True))
+        }
+
     def set_barrier(self, task_id, value='*'):
         self.update_task(task_id, barrier=value)
 

--- a/orquesta/machines.py
+++ b/orquesta/machines.py
@@ -706,7 +706,7 @@ class WorkflowStateMachine(object):
         task_event = tk_ex_event.name
         task_id = getattr(tk_ex_event, 'task_id', None)
         task_route = getattr(tk_ex_event, 'route', None)
-        has_next_tasks = workflow_state.has_next_tasks(task_id, task_route)
+        has_next_tasks = workflow_state.has_next_tasks(task_id, task_route, speculate_join=True)
         has_active_tasks = workflow_state.has_active_tasks
 
         # Mark task remediated if task is in abended statuses and there are transitions.

--- a/orquesta/tests/fixtures/workflows/native/join-all-complex.yaml
+++ b/orquesta/tests/fixtures/workflows/native/join-all-complex.yaml
@@ -1,13 +1,18 @@
 version: 1.0
 
-description: A basic workflow that demonstrate join on count requirement.
+description: >
+    A basic workflow that demonstrate branching and join with multiple
+    inbound task transition from the same task on various condition.
+
+vars:
+  - status: null
 
 tasks:
   task1:
     action: core.noop
     next:
       - when: <% succeeded() %>
-        do: task2, task4, task6
+        do: task2, task4
 
   # branch 1
   task2:
@@ -19,7 +24,13 @@ tasks:
     action: core.noop
     next:
       - when: <% succeeded() %>
-        do: task8
+        publish: status="succeeded" 
+        do: task6
+      - when: <% failed() %>
+        publish: status="failed"
+        do: task6
+      - when: <% completed() %>
+        do: task6
 
   # branch 2
   task4:
@@ -27,33 +38,24 @@ tasks:
     next:
       - when: <% succeeded() %>
         do: task5
-      - when: <% failed() %>
-        do: noop
   task5:
     action: core.noop
     next:
       - when: <% succeeded() %>
-        do: task8
+        publish: status="succeeded"
+        do: task6
       - when: <% failed() %>
-        do: noop
+        publish: status="failed"
+        do: task6
+      - when: <% completed() %>
+        do: task6
 
-  # branch 3
+  # converge branch 1 and 2
   task6:
+    join: all
     action: core.noop
     next:
       - when: <% succeeded() %>
         do: task7
-      - when: <% failed() %>
-        do: noop
   task7:
-    action: core.noop
-    next:
-      - when: <% succeeded() %>
-        do: task8
-      - when: <% failed() %>
-        do: noop
-
-  # converge branches
-  task8:
-    join: 2
     action: core.noop

--- a/orquesta/tests/fixtures/workflows/native/join-count-complex.yaml
+++ b/orquesta/tests/fixtures/workflows/native/join-count-complex.yaml
@@ -1,6 +1,11 @@
 version: 1.0
 
-description: A basic workflow that demonstrate join on count requirement.
+description: >
+    A basic workflow that demonstrate branching and join with multiple
+    inbound task transition from the same task on various condition.
+
+vars:
+  - status: null
 
 tasks:
   task1:
@@ -15,10 +20,18 @@ tasks:
     next:
       - when: <% succeeded() %>
         do: task3
+      - when: <% failed() %>
+        do: noop
   task3:
     action: core.noop
     next:
       - when: <% succeeded() %>
+        publish: status="succeeded" 
+        do: task8
+      - when: <% failed() %>
+        publish: status="failed"
+        do: task8
+      - when: <% completed() %>
         do: task8
 
   # branch 2
@@ -33,9 +46,13 @@ tasks:
     action: core.noop
     next:
       - when: <% succeeded() %>
+        publish: status="succeeded"
         do: task8
       - when: <% failed() %>
-        do: noop
+        publish: status="failed"
+        do: task8
+      - when: <% completed() %>
+        do: task8
 
   # branch 3
   task6:
@@ -49,11 +66,20 @@ tasks:
     action: core.noop
     next:
       - when: <% succeeded() %>
+        publish: status="succeeded"
         do: task8
       - when: <% failed() %>
-        do: noop
+        publish: status="failed"
+        do: task8
+      - when: <% completed() %>
+        do: task8
 
-  # converge branches
+  # converge branch 1, 2, and 3
   task8:
     join: 2
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task9
+  task9:
     action: core.noop

--- a/orquesta/tests/fixtures/workflows/native/join-on-complete.yaml
+++ b/orquesta/tests/fixtures/workflows/native/join-on-complete.yaml
@@ -1,0 +1,45 @@
+version: 1.0
+
+description: A basic workflow that demonstrate branching and join on complete.
+
+tasks:
+  task1:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task2, task4
+
+  # branch 1
+  task2:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task3
+
+  task3:
+    action: core.noop
+    next:
+      - when: <% completed() %>
+        do: task6
+
+  # branch 2
+  task4:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task5
+  task5:
+    action: core.noop
+    next:
+      - when: <% completed() %>
+        do: task6
+
+  # converge branch 1 and 2
+  task6:
+    join: all
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task7
+  task7:
+    action: core.noop

--- a/orquesta/tests/fixtures/workflows/native/join-on-fail.yaml
+++ b/orquesta/tests/fixtures/workflows/native/join-on-fail.yaml
@@ -1,0 +1,45 @@
+version: 1.0
+
+description: A basic workflow that demonstrate branching and join on complete.
+
+tasks:
+  task1:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task2, task4
+
+  # branch 1
+  task2:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task3
+
+  task3:
+    action: core.noop
+    next:
+      - when: <% failed() %>
+        do: task6
+
+  # branch 2
+  task4:
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task5
+  task5:
+    action: core.noop
+    next:
+      - when: <% failed() %>
+        do: task6
+
+  # converge branch 1 and 2
+  task6:
+    join: all
+    action: core.noop
+    next:
+      - when: <% succeeded() %>
+        do: task7
+  task7:
+    action: core.noop

--- a/orquesta/tests/unit/base.py
+++ b/orquesta/tests/unit/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import abc
+import copy
 import six
 from six.moves import queue
 import unittest
@@ -23,7 +24,6 @@ from orquesta.expressions import base as expr_base
 from orquesta.specs import loader as spec_loader
 from orquesta import statuses
 from orquesta.tests.fixtures import loader as fixture_loader
-from orquesta.utils import jsonify as json_util
 from orquesta.utils import plugin as plugin_util
 from orquesta.utils import specs as spec_util
 
@@ -194,13 +194,15 @@ class WorkflowConductorTest(WorkflowComposerTest):
     # order to match in unit tests. This method is used to serialize the task specs and
     # compare the lists.
     def assert_task_list(self, conductor, actual, expected):
-        actual_copy = json_util.deepcopy(actual)
-        expected_copy = json_util.deepcopy(expected)
+        actual_copy = copy.deepcopy(actual)
+        expected_copy = copy.deepcopy(expected)
 
         for task in actual_copy:
             for staged_task in task['ctx']['__state']['staged']:
                 if 'items' in staged_task:
                     del staged_task['items']
+
+            task['spec'] = task['spec'].serialize()
 
         for task in expected_copy:
             task['ctx']['__current_task'] = {'id': task['id'], 'route': task['route']}
@@ -209,6 +211,8 @@ class WorkflowConductorTest(WorkflowComposerTest):
             for staged_task in task['ctx']['__state']['staged']:
                 if 'items' in staged_task:
                     del staged_task['items']
+
+            task['spec'] = task['spec'].serialize()
 
         self.assertListEqual(actual_copy, expected_copy)
 

--- a/orquesta/tests/unit/composition/native/test_workflow_join.py
+++ b/orquesta/tests/unit/composition/native/test_workflow_join.py
@@ -231,7 +231,8 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     'barrier': 2
                 },
                 {
-                    'id': 'noop'
+                    'id': 'noop',
+                    'splits': ['noop']
                 }
             ],
             'adjacency': [
@@ -273,6 +274,12 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                 ],
                 [
                     {
+                        'ref': 1,
+                        'id': 'noop',
+                        'key': 0,
+                        'criteria': ['<% failed() %>']
+                    },
+                    {
                         'id': 'task5',
                         'key': 0,
                         'ref': 0,
@@ -281,6 +288,12 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                 ],
                 [
                     {
+                        'ref': 1,
+                        'id': 'noop',
+                        'key': 0,
+                        'criteria': ['<% failed() %>']
+                    },
+                    {
                         'id': 'task8',
                         'key': 0,
                         'ref': 0,
@@ -288,6 +301,12 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     }
                 ],
                 [
+                    {
+                        'ref': 1,
+                        'id': 'noop',
+                        'key': 0,
+                        'criteria': ['<% failed() %>']
+                    },
                     {
                         'id': 'task7',
                         'key': 0,
@@ -347,7 +366,8 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     'barrier': 2
                 },
                 {
-                    'id': 'noop'
+                    'id': 'noop',
+                    'splits': ['noop']
                 }
             ],
             'adjacency': [
@@ -389,6 +409,12 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                 ],
                 [
                     {
+                        'ref': 1,
+                        'id': 'noop',
+                        'key': 0,
+                        'criteria': ['<% failed() %>']
+                    },
+                    {
                         'id': 'task5',
                         'key': 0,
                         'ref': 0,
@@ -397,6 +423,12 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                 ],
                 [
                     {
+                        'ref': 1,
+                        'id': 'noop',
+                        'key': 0,
+                        'criteria': ['<% failed() %>']
+                    },
+                    {
                         'id': 'task8',
                         'key': 0,
                         'ref': 0,
@@ -404,6 +436,12 @@ class JoinWorkflowComposerTest(base.OrchestraWorkflowComposerTest):
                     }
                 ],
                 [
+                    {
+                        'ref': 1,
+                        'id': 'noop',
+                        'key': 0,
+                        'criteria': ['<% failed() %>']
+                    },
                     {
                         'id': 'task7',
                         'key': 0,

--- a/orquesta/tests/unit/conducting/native/test_workflow_join.py
+++ b/orquesta/tests/unit/conducting/native/test_workflow_join.py
@@ -21,6 +21,9 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
     def test_join(self):
         wf_name = 'join'
 
+        self.assert_spec_inspection(wf_name)
+
+        # Mock successful join.
         expected_task_seq = [
             'task1',
             'task2',
@@ -31,13 +34,10 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             'task7'
         ]
 
-        self.assert_spec_inspection(wf_name)
-
         self.assert_conducting_sequences(wf_name, expected_task_seq)
 
-    def test_join_not_satisfied(self):
-        wf_name = 'join'
-
+        # Both tasks before the join, task3 and task5, failed.
+        # The criteria for the join task is not met.
         expected_task_seq = [
             'task1',
             'task2',
@@ -46,7 +46,6 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             'task5'
         ]
 
-        # The tasks before the join, task3 and task5, both failed.
         mock_statuses = [
             statuses.SUCCEEDED,   # task1
             statuses.SUCCEEDED,   # task2
@@ -65,6 +64,7 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
         )
 
         # First task before the join, task3, failed.
+        # The criteria for the join task is not met.
         mock_statuses = [
             statuses.SUCCEEDED,   # task1
             statuses.SUCCEEDED,   # task2
@@ -83,6 +83,7 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
         )
 
         # Second task before the join, task5, failed.
+        # The criteria for the join task is not met.
         mock_statuses = [
             statuses.SUCCEEDED,   # task1
             statuses.SUCCEEDED,   # task2
@@ -105,7 +106,8 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
 
         self.assert_spec_inspection(wf_name)
 
-        # Mock error at task6
+        # Mock one of the branches is still running and
+        # the join task is satisfied and completed.
         expected_task_seq = [
             'task1',
             'task2',
@@ -133,15 +135,15 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             expected_workflow_status=statuses.RUNNING
         )
 
-        # Mock error at task7
+        # Mock error at task6 of branch 3. The criteria for join task is met.
         expected_task_seq = [
             'task1',
             'task2',
             'task4',
             'task6',
+            ('noop', 1),
             'task3',
             'task5',
-            'task7',
             'task8'
         ]
 
@@ -149,10 +151,9 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             statuses.SUCCEEDED,   # task1
             statuses.SUCCEEDED,   # task2
             statuses.SUCCEEDED,   # task4
-            statuses.SUCCEEDED,   # task6
+            statuses.FAILED,      # task6
             statuses.SUCCEEDED,   # task3
             statuses.SUCCEEDED,   # task5
-            statuses.RUNNING,     # task7
             statuses.SUCCEEDED    # task8
         ]
 
@@ -160,39 +161,10 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             wf_name,
             expected_task_seq,
             mock_statuses=mock_statuses,
-            expected_workflow_status=statuses.RUNNING
+            expected_routes=[[], ['task6__t0']]
         )
 
-    def test_join_count_with_branch_error(self):
-        wf_name = 'join-count'
-
-        self.assert_spec_inspection(wf_name)
-
-        # Mock error at task6. The conductor runs breadth first
-        # and so task3 and task5 has not started.
-        expected_task_seq = [
-            'task1',
-            'task2',
-            'task4',
-            'task6'
-        ]
-
-        mock_statuses = [
-            statuses.SUCCEEDED,   # task1
-            statuses.SUCCEEDED,   # task2
-            statuses.SUCCEEDED,   # task4
-            statuses.FAILED       # task6
-        ]
-
-        self.assert_conducting_sequences(
-            wf_name,
-            expected_task_seq,
-            mock_statuses=mock_statuses,
-            expected_workflow_status=statuses.FAILED
-        )
-
-        # Mock error at task7, note that task3 and task5 have
-        # already satisfied the task8 join requirements.
+        # Mock error at task7 of branch 3. The criteria for join task is not met.
         expected_task_seq = [
             'task1',
             'task2',
@@ -201,7 +173,7 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             'task3',
             'task5',
             'task7',
-            'noop',
+            ('noop', 1),
             'task8'
         ]
 
@@ -213,15 +185,122 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             statuses.SUCCEEDED,   # task3
             statuses.SUCCEEDED,   # task5
             statuses.FAILED,      # task7
-            statuses.SUCCEEDED,   # noop
             statuses.SUCCEEDED    # task8
         ]
 
         self.assert_conducting_sequences(
             wf_name,
             expected_task_seq,
-            mock_statuses=mock_statuses
+            mock_statuses=mock_statuses,
+            expected_routes=[[], ['task7__t0']]
         )
+
+        # Mock errors at branch 2 and 3. The criteria for join task is not met.
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task4',
+            'task6',
+            'task3',
+            'task5',
+            ('noop', 1),
+            'task7',
+            ('noop', 2)
+        ]
+
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED,   # task3
+            statuses.FAILED,      # task5
+            statuses.FAILED,      # task7
+        ]
+
+        conductor = self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses,
+            expected_routes=[[], ['task5__t0'], ['task7__t0']],
+            expected_workflow_status=statuses.FAILED
+        )
+
+        expected_errors = [
+            {
+                "message": "Execution failed. See result for details.",
+                "type": "error",
+                "task_id": "task5"
+            },
+            {
+                "message": "Execution failed. See result for details.",
+                "type": "error",
+                "task_id": "task7"
+            },
+            {
+                "message": (
+                    "UnreachableJoinError: The join task|route \"task8|0\" "
+                    "is partially satisfied but unreachable."
+
+                ),
+                "type": "error",
+                "route": 0,
+                "task_id": "task8"
+            }
+        ]
+
+        self.assertListEqual(conductor.errors, expected_errors)
+
+        # Mock all branches failed. The criteria for join task is not met.
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task4',
+            'task6',
+            'task3',
+            'task5',
+            ('noop', 1),
+            'task7',
+            ('noop', 2)
+        ]
+
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.SUCCEEDED,   # task6
+            statuses.FAILED,      # task3
+            statuses.FAILED,      # task5
+            statuses.FAILED,      # task7
+        ]
+
+        conductor = self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses,
+            expected_routes=[[], ['task5__t0'], ['task7__t0']],
+            expected_workflow_status=statuses.FAILED
+        )
+
+        expected_errors = [
+            {
+                "message": "Execution failed. See result for details.",
+                "type": "error",
+                "task_id": "task3"
+            },
+            {
+                "message": "Execution failed. See result for details.",
+                "type": "error",
+                "task_id": "task5"
+            },
+            {
+                "message": "Execution failed. See result for details.",
+                "type": "error",
+                "task_id": "task7"
+            }
+        ]
+
+        self.assertListEqual(conductor.errors, expected_errors)
 
     def test_join_context(self):
         wf_name = 'join-context'
@@ -478,4 +557,336 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             wf_name,
             expected_task_seq,
             mock_statuses=mock_statuses
+        )
+
+    def test_join_all_complex(self):
+        # In this workflow, both tasks task3 and task5 join all to task6. There
+        # are multiple task transition with different criteria (succeeded,
+        # failed, and completed) defined at each task. All the task transition
+        # specify task6 as the next task. Previously, join all requires all
+        # inbound task transition to pass criteria. So for cases where tasks
+        # defined multiple task transition with different criteria to the same
+        # join task, the join all will never be satisfied. This is now changed
+        # such that as long as there is at least one inbound task transition
+        # from the same task that meets criteria, then the join condition from
+        # that inbound task is considered satisfied.
+        wf_name = 'join-all-complex'
+
+        self.assert_spec_inspection(wf_name)
+
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task4',
+            'task3',
+            'task5',
+            'task6',
+            'task7'
+        ]
+
+        # Both branch 1 and 2 succeeded.
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.SUCCEEDED,   # task3
+            statuses.SUCCEEDED,   # task5
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED    # task7
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses
+        )
+
+        # Both branch 1 and 2 failed and triggering a different
+        # set of task transition but will still join on task6.
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.FAILED,      # task3
+            statuses.FAILED,      # task5
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED    # task7
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses
+        )
+
+        # One of the branches failed and the other succeeded. Each
+        # of the task will trigger different criteria in the task
+        # transition but will still join on task6.
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.FAILED,      # task3
+            statuses.SUCCEEDED,   # task5
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED    # task7
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses
+        )
+
+        # One of the branches succeeded and the other failed. Each
+        # of the task will trigger different criteria in the task
+        # transition but will still join on task6.
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.SUCCEEDED,   # task3
+            statuses.FAILED,      # task5
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED    # task7
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses
+        )
+
+        # Both branch 1 and 2 failed but trigger the set of task
+        # transition that will pass on the failed criteria.
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.FAILED,      # task3
+            statuses.FAILED,      # task5
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED    # task7
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses
+        )
+
+    def test_join_count_complex(self):
+        # In this workflow, the task task3, task5, and task7 join on task8.
+        # There are multiple task transition with different criteria (succeeded,
+        # failed, and completed) defined at each task. All the task transition
+        # specify task8 as the next task. Previously, join count tallies any
+        # inbound task transition to pass criteria. This is now changed such
+        # that the count is on the inbound task and not on task transition.
+        wf_name = 'join-count-complex'
+
+        self.assert_spec_inspection(wf_name)
+
+        # All branches succeeded.
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task4',
+            'task6',
+            'task3',
+            'task5',
+            'task7',
+            'task8',
+            'task9'
+        ]
+
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED,   # task3
+            statuses.SUCCEEDED,   # task5
+            statuses.SUCCEEDED,   # task7
+            statuses.SUCCEEDED,   # task8
+            statuses.SUCCEEDED    # task9
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses
+        )
+
+        # One of three branches failed. Branch 3 failed.
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task4',
+            'task6',
+            ('noop', 1),
+            'task3',
+            'task5',
+            'task8',
+            'task9'
+        ]
+
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.FAILED,      # task6
+            statuses.SUCCEEDED,   # task3
+            statuses.SUCCEEDED,   # task5
+            statuses.SUCCEEDED,   # task8
+            statuses.SUCCEEDED    # task9
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses,
+            expected_routes=[[], ['task6__t0']]
+        )
+
+        # One of three branches failed. Branch 2 failed.
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task4',
+            ('noop', 1),
+            'task6',
+            'task3',
+            'task7',
+            'task8',
+            'task9'
+        ]
+
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.FAILED,      # task4
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED,   # task3
+            statuses.SUCCEEDED,   # task7
+            statuses.SUCCEEDED,   # task8
+            statuses.SUCCEEDED    # task9
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses,
+            expected_routes=[[], ['task4__t0']]
+        )
+
+        # One of three branches failed. Branch 1 failed.
+        expected_task_seq = [
+            'task1',
+            'task2',
+            ('noop', 1),
+            'task4',
+            'task6',
+            'task5',
+            'task7',
+            'task8',
+            'task9'
+        ]
+
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.FAILED,      # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED,   # task3
+            statuses.SUCCEEDED,   # task7
+            statuses.SUCCEEDED,   # task8
+            statuses.SUCCEEDED    # task9
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses,
+            expected_routes=[[], ['task2__t0']]
+        )
+
+        # Two of three branches failed. Branch 2 and 3 failed.
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task4',
+            ('noop', 1),
+            'task6',
+            ('noop', 2),
+            'task3'
+        ]
+
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.FAILED,      # task4
+            statuses.FAILED,      # task6
+            statuses.SUCCEEDED    # task3
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses,
+            expected_routes=[[], ['task4__t0'], ['task6__t0']],
+            expected_workflow_status=statuses.FAILED
+        )
+
+        # Two of three branches failed. Branch 1 and 2 failed.
+        expected_task_seq = [
+            'task1',
+            'task2',
+            ('noop', 1),
+            'task4',
+            ('noop', 2),
+            'task6',
+            'task7'
+        ]
+
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.FAILED,      # task2
+            statuses.FAILED,      # task4
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED    # task7
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses,
+            expected_routes=[[], ['task2__t0'], ['task4__t0']],
+            expected_workflow_status=statuses.FAILED
+        )
+
+        # Two of three branches failed. Branch 1 and 3 failed.
+        expected_task_seq = [
+            'task1',
+            'task2',
+            ('noop', 1),
+            'task4',
+            'task6',
+            ('noop', 2),
+            'task5'
+        ]
+
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.FAILED,      # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.FAILED,      # task6
+            statuses.SUCCEEDED    # task5
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses,
+            expected_routes=[[], ['task2__t0'], ['task6__t0']],
+            expected_workflow_status=statuses.FAILED
         )

--- a/orquesta/tests/unit/conducting/native/test_workflow_join.py
+++ b/orquesta/tests/unit/conducting/native/test_workflow_join.py
@@ -204,3 +204,86 @@ class JoinWorkflowConductorTest(base.OrchestraWorkflowConductorTest):
             mock_results=mock_results,
             expected_output=expected_output
         )
+
+    def test_join_on_complete(self):
+        wf_name = 'join-on-complete'
+
+        self.assert_spec_inspection(wf_name)
+
+        expected_task_seq = [
+            'task1',
+            'task2',
+            'task4',
+            'task3',
+            'task5',
+            'task6',
+            'task7'
+        ]
+
+        # The tasks before the join, task3 and task5, both succeeded.
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.SUCCEEDED,   # task3
+            statuses.SUCCEEDED,   # task5
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED    # task7
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses
+        )
+
+        # First tasks before the join, task3, failed.
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.FAILED,      # task3
+            statuses.SUCCEEDED,   # task5
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED    # task7
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses
+        )
+
+        # Second tasks before the join, task5, failed.
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.SUCCEEDED,   # task3
+            statuses.FAILED,      # task5
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED    # task7
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses
+        )
+
+        # Both tasks before the join, task3 and task5, failed.
+        mock_statuses = [
+            statuses.SUCCEEDED,   # task1
+            statuses.SUCCEEDED,   # task2
+            statuses.SUCCEEDED,   # task4
+            statuses.FAILED,      # task3
+            statuses.FAILED,      # task5
+            statuses.SUCCEEDED,   # task6
+            statuses.SUCCEEDED    # task7
+        ]
+
+        self.assert_conducting_sequences(
+            wf_name,
+            expected_task_seq,
+            mock_statuses=mock_statuses
+        )

--- a/orquesta/tests/unit/graphing/test_workflow_graph.py
+++ b/orquesta/tests/unit/graphing/test_workflow_graph.py
@@ -342,11 +342,17 @@ class WorkflowGraphTest(test_base.WorkflowGraphTest):
             sorted(expected_transitions)
         )
 
-    def test_barrier_task(self):
+    def test_task_has_barrier(self):
         wf_graph = self._prep_graph()
 
         self.assertTrue(wf_graph.has_barrier('task5'))
         self.assertFalse(wf_graph.has_barrier('task9'))
+
+    def test_get_barrier_tasks(self):
+        wf_graph = self._prep_graph()
+
+        expected_result = {'task5': {'barrier': '*'}}
+        self.assertDictEqual(wf_graph.get_barriers(), expected_result)
 
     def test_split_from_reused_task(self):
         wf_graph = self._prep_graph()

--- a/orquesta/utils/jsonify.py
+++ b/orquesta/utils/jsonify.py
@@ -61,8 +61,9 @@ def deepcopy(value):
     # to copy.deepcopy(), but it has some edge cases with non-simple types such as datetimes.
     try:
         value = ujson.loads(ujson.dumps(value))  # pylint: disable=no-member
-    except (OverflowError, ValueError):
-        # NOTE: ujson doesn't support 5 or 6 bytes utf-8 sequences so we fallback to copy.deepcopy.
+    except (OverflowError, ValueError, TypeError):
+        # NOTE: ujson doesn't support 5 or 6 bytes utf-8 sequences or
+        # non-JSON serializable object so we fallback to copy.deepcopy.
         value = copy.deepcopy(value)
 
     return value


### PR DESCRIPTION
Refactor evaluation of inbound criteria for join task on inbound task completion and not on inbound task transition. This allows for different use cases such as multiple task transition from the same inbound task, inbound task transition on completion or inbound task transition on failure. Include additional check in the state machine to detect case where there is an unreachable join task where inbound criteria is partially satisfied but all inbound tasks have already completed and it will never be satisfied.

Fixes https://github.com/StackStorm/orquesta/issues/123
Fixes https://github.com/StackStorm/orquesta/issues/190