### PR TITLE
Fix the yaql/jinja vars extraction to ignore methods of base ctx() dict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,8 @@ Fixed
 * When inspecting custom YAQL/Jinja function to see if there is a context arg, use getargspec
   for py2 and getfullargspec for py3. (bug fix)
 * Check syntax on with items task to ensure action is indented correctly. Fixes #184 (bug fix)
+* Fix variable inspection where ctx().get() method calls are identified as errors.
+  Fixes StackStorm/st2#4866 (bug fix)
 
 1.0.0
 -----

--- a/orquesta/expressions/base.py
+++ b/orquesta/expressions/base.py
@@ -144,7 +144,6 @@ def evaluate(statement, data=None):
 
 
 def extract_vars(statement):
-
     variables = []
 
     if isinstance(statement, dict):

--- a/orquesta/expressions/jinja.py
+++ b/orquesta/expressions/jinja.py
@@ -54,14 +54,14 @@ class JinjaEvaluator(expr_base.Evaluator):
     _regex_pattern = '{{.*?}}'
     _regex_parser = re.compile(_regex_pattern)
 
-    _regex_reference_pattern = r'[][a-zA-Z0-9_\'"\.()]*'
+    _regex_ctx_ref_pattern = r'[][a-zA-Z0-9_\'"\.()]*'
     # match any of:
     #   word boundary ctx(*)
     #   word boundary ctx()*
     #   word boundary ctx().*
     #   word boundary ctx(*)*
     #   word boundary ctx(*).*
-    _regex_ctx_pattern = r'\bctx\([\'"]?{0}[\'"]?\)\.?{0}'.format(_regex_reference_pattern)
+    _regex_ctx_pattern = r'\bctx\([\'"]?{0}[\'"]?\)\.?{0}'.format(_regex_ctx_ref_pattern)
     _regex_ctx_var_parser = re.compile(_regex_ctx_pattern)
 
     _regex_var = r'[a-zA-Z0-9_-]+'

--- a/orquesta/expressions/jinja.py
+++ b/orquesta/expressions/jinja.py
@@ -54,17 +54,17 @@ class JinjaEvaluator(expr_base.Evaluator):
     _regex_pattern = '{{.*?}}'
     _regex_parser = re.compile(_regex_pattern)
 
-    _regex_ctx_pattern = '[a-zA-Z0-9_\'"\.\[\]\(\)]*'
+    _regex_ctx_pattern = r'[a-zA-Z0-9_\'"\.\[\]\(\)]*'
     _regex_ctx_patterns = [
-        '^ctx\(\)\.%s' % _regex_ctx_pattern,                                # line start ctx().*
-        '^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern),     # line start ctx(*).*
-        '[\s]ctx\(\)\.%s' % _regex_ctx_pattern,                             # whitespace ctx().*
-        '[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern)   # whitespace ctx(*).*
+        r'^ctx\(\)\.%s' % _regex_ctx_pattern,                                # line start ctx().*
+        r'^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern),     # line start ctx(*).*
+        r'[\s]ctx\(\)\.%s' % _regex_ctx_pattern,                             # whitespace ctx().*
+        r'[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern)   # whitespace ctx(*).*
     ]
-    _regex_ctx_var = '.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
+    _regex_ctx_var = r'.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
     _regex_ctx_var_parser = re.compile(_regex_ctx_var)
 
-    _regex_var = '[a-zA-Z0-9_\-]+'
+    _regex_var = r'[a-zA-Z0-9_\-]+'
     _regex_var_extracts = [
         r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,                   # extract x in ctx().x
         r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                       # extract x in ctx(x)

--- a/orquesta/expressions/jinja.py
+++ b/orquesta/expressions/jinja.py
@@ -54,26 +54,26 @@ class JinjaEvaluator(expr_base.Evaluator):
     _regex_pattern = '{{.*?}}'
     _regex_parser = re.compile(_regex_pattern)
 
-    _regex_dot_pattern = '[a-zA-Z0-9_\'"\.\[\]\(\)]*'
+    _regex_ctx_pattern = '[a-zA-Z0-9_\'"\.\[\]\(\)]*'
     _regex_ctx_patterns = [
-        '^ctx\(\)\.%s' % _regex_dot_pattern,                                # line start ctx().*
-        '^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_dot_pattern),     # line start ctx(*).*
-        '[\s]ctx\(\)\.%s' % _regex_dot_pattern,                             # whitespace ctx().*
-        '[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_dot_pattern)   # whitespace ctx(*).*
+        '^ctx\(\)\.%s' % _regex_ctx_pattern,                                # line start ctx().*
+        '^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern),     # line start ctx(*).*
+        '[\s]ctx\(\)\.%s' % _regex_ctx_pattern,                             # whitespace ctx().*
+        '[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern)   # whitespace ctx(*).*
     ]
-    _regex_var_pattern = '.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
-    _regex_var_parser = re.compile(_regex_var_pattern)
+    _regex_ctx_var = '.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
+    _regex_ctx_var_parser = re.compile(_regex_ctx_var)
 
-    _regex_dot_extract = '[a-zA-Z0-9_\-]+'
+    _regex_var = '[a-zA-Z0-9_\-]+'
     _regex_var_extracts = [
-        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_dot_extract,       # line start ctx().foobar
-        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_dot_extract,           # line start ctx(foobar)
-        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_dot_extract,       # line start ctx('foobar')
-        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_dot_extract,         # line start ctx("foobar")
-        r'(?<=[\s]ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_dot_extract,    # whitespace ctx().foobar
-        r'(?<=[\s]ctx\()(\b%s\b)(?=\))\.?' % _regex_dot_extract,        # whitespace ctx(foobar)
-        r'(?<=[\s]ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_dot_extract,    # whitespace ctx('foobar')
-        r'(?<=[\s]ctx\(")(\b%s\b)(?="\))\.?' % _regex_dot_extract       # whitespace ctx("foobar")
+        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,               # line start ctx().x
+        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                   # line start ctx(x)
+        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,               # line start ctx('x')
+        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_var,                 # line start ctx("x")
+        r'(?<=[\s]ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,            # whitespace ctx().x
+        r'(?<=[\s]ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                # whitespace ctx(x)
+        r'(?<=[\s]ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,            # whitespace ctx('x')
+        r'(?<=[\s]ctx\(")(\b%s\b)(?="\))\.?' % _regex_var               # whitespace ctx("x")
     ]
 
     _block_delimiter = '{%}'
@@ -247,7 +247,7 @@ class JinjaEvaluator(expr_base.Evaluator):
             raise ValueError('Text to be evaluated is not typeof string.')
 
         results = [
-            cls._regex_var_parser.findall(expr.strip(cls._delimiter).strip())
+            cls._regex_ctx_var_parser.findall(expr.strip(cls._delimiter).strip())
             for expr in cls._regex_parser.findall(text)
         ]
 

--- a/orquesta/expressions/jinja.py
+++ b/orquesta/expressions/jinja.py
@@ -66,14 +66,10 @@ class JinjaEvaluator(expr_base.Evaluator):
 
     _regex_var = '[a-zA-Z0-9_\-]+'
     _regex_var_extracts = [
-        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,               # line start ctx().x
-        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                   # line start ctx(x)
-        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,               # line start ctx('x')
-        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_var,                 # line start ctx("x")
-        r'(?<=[\s]ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,            # whitespace ctx().x
-        r'(?<=[\s]ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                # whitespace ctx(x)
-        r'(?<=[\s]ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,            # whitespace ctx('x')
-        r'(?<=[\s]ctx\(")(\b%s\b)(?="\))\.?' % _regex_var               # whitespace ctx("x")
+        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,                   # extract x in ctx().x
+        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                       # extract x in ctx(x)
+        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,                   # extract x in ctx('x')
+        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_var                      # extract x in ctx("x")
     ]
 
     _block_delimiter = '{%}'

--- a/orquesta/expressions/yql.py
+++ b/orquesta/expressions/yql.py
@@ -54,26 +54,26 @@ class YAQLEvaluator(expr_base.Evaluator):
     _regex_pattern = '<%.*?%>'
     _regex_parser = re.compile(_regex_pattern)
 
-    _regex_dot_pattern = '[a-zA-Z0-9_\'"\.\[\]\(\)]*'
+    _regex_ctx_pattern = '[a-zA-Z0-9_\'"\.\[\]\(\)]*'
     _regex_ctx_patterns = [
-        '^ctx\(\)\.%s' % _regex_dot_pattern,                                # line start ctx().*
-        '^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_dot_pattern),     # line start ctx(*).*
-        '[\s]ctx\(\)\.%s' % _regex_dot_pattern,                             # whitespace ctx().*
-        '[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_dot_pattern)   # whitespace ctx(*).*
+        '^ctx\(\)\.%s' % _regex_ctx_pattern,                                # line start ctx().*
+        '^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern),     # line start ctx(*).*
+        '[\s]ctx\(\)\.%s' % _regex_ctx_pattern,                             # whitespace ctx().*
+        '[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern)   # whitespace ctx(*).*
     ]
-    _regex_var_pattern = '.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
-    _regex_var_parser = re.compile(_regex_var_pattern)
+    _regex_ctx_var = '.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
+    _regex_ctx_var_parser = re.compile(_regex_ctx_var)
 
-    _regex_dot_extract = '[a-zA-Z0-9_\-]+'
+    _regex_var = '[a-zA-Z0-9_\-]+'
     _regex_var_extracts = [
-        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_dot_extract,       # line start ctx().foobar
-        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_dot_extract,           # line start ctx(foobar)
-        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_dot_extract,       # line start ctx('foobar')
-        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_dot_extract,         # line start ctx("foobar")
-        r'(?<=[\s]ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_dot_extract,    # whitespace ctx().foobar
-        r'(?<=[\s]ctx\()(\b%s\b)(?=\))\.?' % _regex_dot_extract,        # whitespace ctx(foobar)
-        r'(?<=[\s]ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_dot_extract,    # whitespace ctx('foobar')
-        r'(?<=[\s]ctx\(")(\b%s\b)(?="\))\.?' % _regex_dot_extract       # whitespace ctx("foobar")
+        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,               # line start ctx().x
+        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                   # line start ctx(x)
+        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,               # line start ctx('x')
+        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_var,                 # line start ctx("x")
+        r'(?<=[\s]ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,            # whitespace ctx().x
+        r'(?<=[\s]ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                # whitespace ctx(x)
+        r'(?<=[\s]ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,            # whitespace ctx('x')
+        r'(?<=[\s]ctx\(")(\b%s\b)(?="\))\.?' % _regex_var               # whitespace ctx("x")
     ]
 
     _engine = yaql.language.factory.YaqlFactory().create()
@@ -166,7 +166,7 @@ class YAQLEvaluator(expr_base.Evaluator):
             raise ValueError('Text to be evaluated is not typeof string.')
 
         results = [
-            cls._regex_var_parser.findall(expr.strip(cls._delimiter).strip())
+            cls._regex_ctx_var_parser.findall(expr.strip(cls._delimiter).strip())
             for expr in cls._regex_parser.findall(text)
         ]
 

--- a/orquesta/expressions/yql.py
+++ b/orquesta/expressions/yql.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import inspect
+import itertools
 import logging
 import re
 import six
@@ -54,15 +55,26 @@ class YAQLEvaluator(expr_base.Evaluator):
     _regex_parser = re.compile(_regex_pattern)
 
     _regex_dot_pattern = '[a-zA-Z0-9_\'"\.\[\]\(\)]*'
-    _regex_ctx_pattern_1 = 'ctx\(\)\.%s' % _regex_dot_pattern
-    _regex_ctx_pattern_2 = 'ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_dot_pattern)
-    _regex_var_pattern = '.*?(%s|%s).*?' % (_regex_ctx_pattern_1, _regex_ctx_pattern_2)
+    _regex_ctx_patterns = [
+        '^ctx\(\)\.%s' % _regex_dot_pattern,                                # line start ctx().*
+        '^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_dot_pattern),     # line start ctx(*).*
+        '[\s]ctx\(\)\.%s' % _regex_dot_pattern,                             # whitespace ctx().*
+        '[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_dot_pattern)   # whitespace ctx(*).*
+    ]
+    _regex_var_pattern = '.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
     _regex_var_parser = re.compile(_regex_var_pattern)
 
-    _regex_dot_extract = '([a-zA-Z0-9_\-]*)'
-    _regex_ctx_extract_1 = 'ctx\(\)\.%s' % _regex_dot_extract
-    _regex_ctx_extract_2 = 'ctx\([\'|"]?%s(%s)' % (_regex_dot_extract, _regex_dot_pattern)
-    _regex_var_extracts = ['%s\.?' % _regex_ctx_extract_1, '%s\.?' % _regex_ctx_extract_2]
+    _regex_dot_extract = '[a-zA-Z0-9_\-]+'
+    _regex_var_extracts = [
+        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_dot_extract,       # line start ctx().foobar
+        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_dot_extract,           # line start ctx(foobar)
+        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_dot_extract,       # line start ctx('foobar')
+        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_dot_extract,         # line start ctx("foobar")
+        r'(?<=[\s]ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_dot_extract,    # whitespace ctx().foobar
+        r'(?<=[\s]ctx\()(\b%s\b)(?=\))\.?' % _regex_dot_extract,        # whitespace ctx(foobar)
+        r'(?<=[\s]ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_dot_extract,    # whitespace ctx('foobar')
+        r'(?<=[\s]ctx\(")(\b%s\b)(?="\))\.?' % _regex_dot_extract       # whitespace ctx("foobar")
+    ]
 
     _engine = yaql.language.factory.YaqlFactory().create()
     _root_ctx = yaql.create_context()
@@ -153,9 +165,11 @@ class YAQLEvaluator(expr_base.Evaluator):
         if not isinstance(text, six.string_types):
             raise ValueError('Text to be evaluated is not typeof string.')
 
-        variables = []
+        results = [
+            cls._regex_var_parser.findall(expr.strip(cls._delimiter).strip())
+            for expr in cls._regex_parser.findall(text)
+        ]
 
-        for expr in cls._regex_parser.findall(text):
-            variables.extend(cls._regex_var_parser.findall(expr))
+        variables = [v.strip() for v in itertools.chain.from_iterable(results)]
 
         return sorted(list(set(variables)))

--- a/orquesta/expressions/yql.py
+++ b/orquesta/expressions/yql.py
@@ -54,17 +54,17 @@ class YAQLEvaluator(expr_base.Evaluator):
     _regex_pattern = '<%.*?%>'
     _regex_parser = re.compile(_regex_pattern)
 
-    _regex_ctx_pattern = '[a-zA-Z0-9_\'"\.\[\]\(\)]*'
+    _regex_ctx_pattern = r'[a-zA-Z0-9_\'"\.\[\]\(\)]*'
     _regex_ctx_patterns = [
-        '^ctx\(\)\.%s' % _regex_ctx_pattern,                                # line start ctx().*
-        '^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern),     # line start ctx(*).*
-        '[\s]ctx\(\)\.%s' % _regex_ctx_pattern,                             # whitespace ctx().*
-        '[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern)   # whitespace ctx(*).*
+        r'^ctx\(\)\.%s' % _regex_ctx_pattern,                                # line start ctx().*
+        r'^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern),     # line start ctx(*).*
+        r'[\s]ctx\(\)\.%s' % _regex_ctx_pattern,                             # whitespace ctx().*
+        r'[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern)   # whitespace ctx(*).*
     ]
-    _regex_ctx_var = '.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
+    _regex_ctx_var = r'.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
     _regex_ctx_var_parser = re.compile(_regex_ctx_var)
 
-    _regex_var = '[a-zA-Z0-9_\-]+'
+    _regex_var = r'[a-zA-Z0-9_\-]+'
     _regex_var_extracts = [
         r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,                   # extract x in ctx().x
         r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                       # extract x in ctx(x)

--- a/orquesta/expressions/yql.py
+++ b/orquesta/expressions/yql.py
@@ -66,14 +66,10 @@ class YAQLEvaluator(expr_base.Evaluator):
 
     _regex_var = '[a-zA-Z0-9_\-]+'
     _regex_var_extracts = [
-        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,               # line start ctx().x
-        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                   # line start ctx(x)
-        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,               # line start ctx('x')
-        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_var,                 # line start ctx("x")
-        r'(?<=[\s]ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,            # whitespace ctx().x
-        r'(?<=[\s]ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                # whitespace ctx(x)
-        r'(?<=[\s]ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,            # whitespace ctx('x')
-        r'(?<=[\s]ctx\(")(\b%s\b)(?="\))\.?' % _regex_var               # whitespace ctx("x")
+        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,                   # extract x in ctx().x
+        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                       # extract x in ctx(x)
+        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,                   # extract x in ctx('x')
+        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_var                      # extract x in ctx("x")
     ]
 
     _engine = yaql.language.factory.YaqlFactory().create()

--- a/orquesta/expressions/yql.py
+++ b/orquesta/expressions/yql.py
@@ -54,22 +54,22 @@ class YAQLEvaluator(expr_base.Evaluator):
     _regex_pattern = '<%.*?%>'
     _regex_parser = re.compile(_regex_pattern)
 
-    _regex_ctx_pattern = r'[a-zA-Z0-9_\'"\.\[\]\(\)]*'
-    _regex_ctx_patterns = [
-        r'^ctx\(\)\.%s' % _regex_ctx_pattern,                                # line start ctx().*
-        r'^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern),     # line start ctx(*).*
-        r'[\s]ctx\(\)\.%s' % _regex_ctx_pattern,                             # whitespace ctx().*
-        r'[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern)   # whitespace ctx(*).*
-    ]
-    _regex_ctx_var = r'.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
-    _regex_ctx_var_parser = re.compile(_regex_ctx_var)
+    _regex_ctx_ref_pattern = r'[][a-zA-Z0-9_\'"\.()]*'
+    # match any of:
+    #   word boundary ctx(*)
+    #   word boundary ctx()*
+    #   word boundary ctx().*
+    #   word boundary ctx(*)*
+    #   word boundary ctx(*).*
+    _regex_ctx_pattern = r'\bctx\([\'"]?{0}[\'"]?\)\.?{0}'.format(_regex_ctx_ref_pattern)
+    _regex_ctx_var_parser = re.compile(_regex_ctx_pattern)
 
-    _regex_var = r'[a-zA-Z0-9_\-]+'
+    _regex_var = r'[a-zA-Z0-9_-]+'
     _regex_var_extracts = [
-        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,                   # extract x in ctx().x
-        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                       # extract x in ctx(x)
-        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,                   # extract x in ctx('x')
-        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_var                      # extract x in ctx("x")
+        r'(?<=\bctx\(\)\.)({})\b(?!\()\.?'.format(_regex_var),              # extract x in ctx().x
+        r'(?:\bctx\(({})\))'.format(_regex_var),                            # extract x in ctx(x)
+        r'(?:\bctx\(\'({})\'\))'.format(_regex_var),                        # extract x in ctx('x')
+        r'(?:\bctx\("({})"\))'.format(_regex_var)                           # extract x in ctx("x")
     ]
 
     _engine = yaql.language.factory.YaqlFactory().create()

--- a/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_dot_notation.py
+++ b/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_dot_notation.py
@@ -19,7 +19,7 @@ from orquesta.tests.unit import base as test_base
 class JinjaFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
 
     def test_empty_extraction(self):
-        expr = '{{ just_text and _not_a_var }}'
+        expr = '{{ just_text and _not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') }}'
 
         self.assertListEqual([], expr_base.extract_vars(expr))
 
@@ -52,12 +52,14 @@ class JinjaFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest)
         self.assertListEqual(expected_vars, expr_base.extract_vars(expr))
 
     def test_multiple_vars_extraction(self):
-        expr = '{{ ctx().foobar ctx().foo.get(bar) ctx().fu.bar ctx().fu.bar[0] }}'
+        expr = '{{ctx().fubar ctx().foobar ctx().foo.get(bar) ctx().fu.bar ctx().foobaz.bar[0] }}'
 
         expected_vars = [
             ('jinja', expr, 'foo'),
             ('jinja', expr, 'foobar'),
-            ('jinja', expr, 'fu')
+            ('jinja', expr, 'foobaz'),
+            ('jinja', expr, 'fu'),
+            ('jinja', expr, 'fubar')
         ]
 
         self.assertListEqual(expected_vars, expr_base.extract_vars(expr))

--- a/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_dot_notation.py
+++ b/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_dot_notation.py
@@ -20,8 +20,9 @@ class JinjaFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest)
 
     def test_empty_extraction(self):
         expr = (
-            '{{ just_text and _not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') '
-            'and ctx(). and ctx().() and ctx().-foobar and ctx().foobar() }}')
+            '{{ just_text and $not_a_var and notctx().bar and '
+            'ctx(). and ctx().() and ctx().-foobar and ctx().foobar() }}'
+        )
 
         self.assertListEqual([], expr_base.extract_vars(expr))
 

--- a/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_function_arg.py
@@ -19,7 +19,7 @@ from orquesta.tests.unit import base as test_base
 class JinjaFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
 
     def test_empty_extraction(self):
-        expr = '{{ just_text and _not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') }}'
+        expr = '{{ just_text and $not_a_var and notctx(foo) and notctx("bar") and notctx(\'fu\') }}'
 
         self.assertListEqual([], expr_base.extract_vars(expr))
 
@@ -116,6 +116,16 @@ class JinjaFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest)
 
     def test_ignore_ctx_dict_funcs(self):
         expr = '{{ctx().keys() and ctx().values() and ctx().set("b", 3) }}'
+
+        expected_vars = []
+
+        self.assertListEqual(expected_vars, expr_base.extract_vars(expr))
+
+    def test_ignore_ctx_get_func_calls(self):
+        expr = (
+            '{{ctx().get(foo) and ctx().get(bar) and ctx().get("fu") and ctx().get(\'baz\') and '
+            'ctx().get(foo, "bar") and ctx().get("fu", "bar") and ctx().get(\'bar\', \'foo\') }}'
+        )
 
         expected_vars = []
 

--- a/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_function_arg.py
@@ -19,7 +19,12 @@ from orquesta.tests.unit import base as test_base
 class JinjaFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
 
     def test_empty_extraction(self):
-        expr = '{{ just_text and $not_a_var and notctx(foo) and notctx("bar") and notctx(\'fu\') }}'
+        expr = (
+            '{{ just_text and $not_a_var and '
+            'notctx(foo) and notctx("bar") and notctx(\'fu\') '
+            'ctx("foo\') and ctx(\'foo") and ctx(foo") and '
+            'ctx("foo) and ctx(foo\') and ctx(\'foo) }}'
+        )
 
         self.assertListEqual([], expr_base.extract_vars(expr))
 
@@ -124,7 +129,8 @@ class JinjaFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest)
     def test_ignore_ctx_get_func_calls(self):
         expr = (
             '{{ctx().get(foo) and ctx().get(bar) and ctx().get("fu") and ctx().get(\'baz\') and '
-            'ctx().get(foo, "bar") and ctx().get("fu", "bar") and ctx().get(\'bar\', \'foo\') }}'
+            'ctx().get(foo, "bar") and ctx().get("fu", "bar") and ctx().get(\'bar\', \'foo\') and '
+            'ctx().get("foo\') and ctx().get(\'foo") and ctx().get("foo) and ctx().get(foo") }}'
         )
 
         expected_vars = []

--- a/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_function_arg.py
@@ -23,7 +23,10 @@ class JinjaFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest)
             '{{ just_text and $not_a_var and '
             'notctx(foo) and notctx("bar") and notctx(\'fu\') '
             'ctx("foo\') and ctx(\'foo") and ctx(foo") and '
-            'ctx("foo) and ctx(foo\') and ctx(\'foo) and ctx(-foobar) }}'
+            'ctx("foo) and ctx(foo\') and ctx(\'foo) and '
+            'ctx(-foo) and ctx("-bar") and ctx(\'-fu\') and '
+            'ctx(foo.bar) and ctx("foo.bar") and ctx(\'foo.bar\') and '
+            'ctx(foo()) and ctx("foo()") and ctx(\'foo()\') }}'
         )
 
         self.assertListEqual([], expr_base.extract_vars(expr))

--- a/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_dot_notation.py
+++ b/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_dot_notation.py
@@ -19,7 +19,10 @@ from orquesta.tests.unit import base as test_base
 class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
 
     def test_empty_extraction(self):
-        expr = '<% just_text and $not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') %>'
+        expr = (
+            '<% just_text and $not_a_var and notctx().bar and '
+            'ctx(). and ctx().() and ctx().-foobar and ctx().foobar() %>'
+        )
 
         self.assertListEqual([], expr_base.extract_vars(expr))
 

--- a/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_dot_notation.py
+++ b/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_dot_notation.py
@@ -19,7 +19,7 @@ from orquesta.tests.unit import base as test_base
 class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
 
     def test_empty_extraction(self):
-        expr = '<% just_text and $not_a_var %>'
+        expr = '<% just_text and $not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') %>'
 
         self.assertListEqual([], expr_base.extract_vars(expr))
 
@@ -52,12 +52,14 @@ class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
         self.assertListEqual(expected_vars, expr_base.extract_vars(expr))
 
     def test_multiple_vars_extraction(self):
-        expr = '<% ctx().foobar ctx().foo.get(bar) ctx().fu.bar ctx().fu.bar[0] %>'
+        expr = '<%ctx().fubar ctx().foobar ctx().foo.get(bar) ctx().fu.bar ctx().foobaz.bar[0] %>'
 
         expected_vars = [
             ('yaql', expr, 'foo'),
             ('yaql', expr, 'foobar'),
-            ('yaql', expr, 'fu')
+            ('yaql', expr, 'foobaz'),
+            ('yaql', expr, 'fu'),
+            ('yaql', expr, 'fubar')
         ]
 
         self.assertListEqual(expected_vars, expr_base.extract_vars(expr))

--- a/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_function_arg.py
@@ -19,7 +19,7 @@ from orquesta.tests.unit import base as test_base
 class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
 
     def test_empty_extraction(self):
-        expr = '<% just_text and $not_a_var %>'
+        expr = '<% just_text and $not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') %>'
 
         self.assertListEqual([], expr_base.extract_vars(expr))
 
@@ -52,12 +52,14 @@ class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
         self.assertListEqual(expected_vars, expr_base.extract_vars(expr))
 
     def test_multiple_vars_extraction(self):
-        expr = '<% ctx(foobar) ctx(foo).get(bar) ctx(fu).bar ctx(fu).bar[0] %>'
+        expr = '<%ctx(fubar) ctx(foobar) ctx(foo).get(bar) ctx(fu).bar ctx(foobaz).bar[0] %>'
 
         expected_vars = [
             ('yaql', expr, 'foo'),
             ('yaql', expr, 'foobar'),
-            ('yaql', expr, 'fu')
+            ('yaql', expr, 'foobaz'),
+            ('yaql', expr, 'fu'),
+            ('yaql', expr, 'fubar')
         ]
 
         self.assertListEqual(expected_vars, expr_base.extract_vars(expr))
@@ -106,5 +108,12 @@ class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
             ('yaql', '<% ctx(y) %>', 'y'),
             ('yaql', '<% ctx(z) %>', 'z')
         ]
+
+        self.assertListEqual(expected_vars, expr_base.extract_vars(expr))
+
+    def test_ignore_ctx_dict_funcs(self):
+        expr = '<%ctx().keys() and ctx().values() and ctx().set("b", 3) %>'
+
+        expected_vars = []
 
         self.assertListEqual(expected_vars, expr_base.extract_vars(expr))

--- a/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_function_arg.py
@@ -19,7 +19,7 @@ from orquesta.tests.unit import base as test_base
 class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
 
     def test_empty_extraction(self):
-        expr = '<% just_text and $not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') %>'
+        expr = '<% just_text and $not_a_var and notctx(foo) and notctx("bar") and notctx(\'fu\') %>'
 
         self.assertListEqual([], expr_base.extract_vars(expr))
 
@@ -113,6 +113,16 @@ class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
 
     def test_ignore_ctx_dict_funcs(self):
         expr = '<%ctx().keys() and ctx().values() and ctx().set("b", 3) %>'
+
+        expected_vars = []
+
+        self.assertListEqual(expected_vars, expr_base.extract_vars(expr))
+
+    def test_ignore_ctx_get_func_calls(self):
+        expr = (
+            '<%ctx().get(foo) and ctx().get(bar) and ctx().get("fu") and ctx().get(\'baz\') and '
+            'ctx().get(foo, "bar") and ctx().get("fu", "bar") and ctx().get(\'bar\', \'foo\') %>'
+        )
 
         expected_vars = []
 

--- a/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_function_arg.py
@@ -23,7 +23,10 @@ class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
             '<% just_text and $not_a_var and '
             'notctx(foo) and notctx("bar") and notctx(\'fu\') '
             'ctx("foo\') and ctx(\'foo") and ctx(foo") and '
-            'ctx("foo) and ctx(foo\') and ctx(\'foo) %>'
+            'ctx("foo) and ctx(foo\') and ctx(\'foo) and '
+            'ctx(-foo) and ctx("-bar") and ctx(\'-fu\') and '
+            'ctx(foo.bar) and ctx("foo.bar") and ctx(\'foo.bar\') and '
+            'ctx(foo()) and ctx("foo()") and ctx(\'foo()\') %>'
         )
 
         self.assertListEqual([], expr_base.extract_vars(expr))

--- a/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_facade_yaql_ctx_by_function_arg.py
@@ -19,7 +19,12 @@ from orquesta.tests.unit import base as test_base
 class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
 
     def test_empty_extraction(self):
-        expr = '<% just_text and $not_a_var and notctx(foo) and notctx("bar") and notctx(\'fu\') %>'
+        expr = (
+            '<% just_text and $not_a_var and '
+            'notctx(foo) and notctx("bar") and notctx(\'fu\') '
+            'ctx("foo\') and ctx(\'foo") and ctx(foo") and '
+            'ctx("foo) and ctx(foo\') and ctx(\'foo) %>'
+        )
 
         self.assertListEqual([], expr_base.extract_vars(expr))
 
@@ -121,7 +126,8 @@ class YAQLFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
     def test_ignore_ctx_get_func_calls(self):
         expr = (
             '<%ctx().get(foo) and ctx().get(bar) and ctx().get("fu") and ctx().get(\'baz\') and '
-            'ctx().get(foo, "bar") and ctx().get("fu", "bar") and ctx().get(\'bar\', \'foo\') %>'
+            'ctx().get(foo, "bar") and ctx().get("fu", "bar") and ctx().get(\'bar\', \'foo\') and '
+            'ctx().get("foo\') and ctx().get(\'foo") and ctx().get("foo) and ctx().get(foo") %>'
         )
 
         expected_vars = []

--- a/orquesta/tests/unit/expressions/test_jinja_ctx_by_dot_notation.py
+++ b/orquesta/tests/unit/expressions/test_jinja_ctx_by_dot_notation.py
@@ -23,7 +23,7 @@ class JinjaVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         super(JinjaVariableExtractionTest, cls).setUpClass()
 
     def test_empty_extraction(self):
-        expr = '{{ just_text and _not_a_var }}'
+        expr = '{{ just_text and _not_a_var and fooctx().bar }}'
 
         self.assertListEqual([], self.evaluator.extract_vars(expr))
 
@@ -64,13 +64,14 @@ class JinjaVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         self.assertListEqual(expected_vars, self.evaluator.extract_vars(expr))
 
     def test_multiple_vars_extraction(self):
-        expr = '{{ ctx().foobar ctx().foo.get(bar) ctx().fu.bar ctx().fu.bar[0] }}'
+        expr = '{{ctx().fubar ctx().foobar ctx().foo.get(bar) ctx().fu.bar ctx().foobaz.bar[0] }}'
 
         expected_vars = [
             'ctx().foobar',
+            'ctx().foobaz.bar[0]',
             'ctx().foo.get(bar)',
-            'ctx().fu.bar',
-            'ctx().fu.bar[0]'
+            'ctx().fubar',
+            'ctx().fu.bar'
         ]
 
         self.assertListEqual(

--- a/orquesta/tests/unit/expressions/test_jinja_ctx_by_dot_notation.py
+++ b/orquesta/tests/unit/expressions/test_jinja_ctx_by_dot_notation.py
@@ -23,7 +23,7 @@ class JinjaVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         super(JinjaVariableExtractionTest, cls).setUpClass()
 
     def test_empty_extraction(self):
-        expr = '{{ just_text and _not_a_var and fooctx().bar }}'
+        expr = '{{ just_text and $not_a_var and notctx().bar }}'
 
         self.assertListEqual([], self.evaluator.extract_vars(expr))
 

--- a/orquesta/tests/unit/expressions/test_jinja_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_jinja_ctx_by_function_arg.py
@@ -23,7 +23,7 @@ class JinjaVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         super(JinjaVariableExtractionTest, cls).setUpClass()
 
     def test_empty_extraction(self):
-        expr = '{{ just_text and _not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') }}'
+        expr = '{{ just_text and $not_a_var and notctx(foo) and notctx("bar") and notctx(\'fu\') }}'
 
         self.assertListEqual([], self.evaluator.extract_vars(expr))
 

--- a/orquesta/tests/unit/expressions/test_jinja_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_jinja_ctx_by_function_arg.py
@@ -23,7 +23,7 @@ class JinjaVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         super(JinjaVariableExtractionTest, cls).setUpClass()
 
     def test_empty_extraction(self):
-        expr = '{{ just_text and _not_a_var }}'
+        expr = '{{ just_text and _not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') }}'
 
         self.assertListEqual([], self.evaluator.extract_vars(expr))
 
@@ -82,13 +82,14 @@ class JinjaVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         self.assertListEqual(expected_vars, self.evaluator.extract_vars(expr))
 
     def test_multiple_vars_extraction(self):
-        expr = '{{ ctx(foobar) ctx(foo).get(bar) ctx(fu).bar ctx(fu).bar[0]  }}'
+        expr = '{{ctx(fubar) ctx(foobar) ctx(foo).get(bar) ctx(fu).bar ctx(foobaz).bar[0]  }}'
 
         expected_vars = [
             'ctx(foobar)',
+            'ctx(foobaz).bar[0]',
             'ctx(foo).get(bar)',
-            'ctx(fu).bar',
-            'ctx(fu).bar[0]'
+            'ctx(fubar)',
+            'ctx(fu).bar'
         ]
 
         self.assertListEqual(

--- a/orquesta/tests/unit/expressions/test_yaql_ctx_by_dot_notation.py
+++ b/orquesta/tests/unit/expressions/test_yaql_ctx_by_dot_notation.py
@@ -23,7 +23,7 @@ class YAQLVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         super(YAQLVariableExtractionTest, cls).setUpClass()
 
     def test_empty_extraction(self):
-        expr = '<% just_text and $not_a_var and fooctx().bar %>'
+        expr = '<% just_text and $not_a_var and notctx().bar %>'
 
         self.assertListEqual([], self.evaluator.extract_vars(expr))
 

--- a/orquesta/tests/unit/expressions/test_yaql_ctx_by_dot_notation.py
+++ b/orquesta/tests/unit/expressions/test_yaql_ctx_by_dot_notation.py
@@ -23,7 +23,7 @@ class YAQLVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         super(YAQLVariableExtractionTest, cls).setUpClass()
 
     def test_empty_extraction(self):
-        expr = '<% just_text and $not_a_var %>'
+        expr = '<% just_text and $not_a_var and fooctx().bar %>'
 
         self.assertListEqual([], self.evaluator.extract_vars(expr))
 
@@ -64,13 +64,14 @@ class YAQLVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         self.assertListEqual(expected_vars, self.evaluator.extract_vars(expr))
 
     def test_multiple_vars_extraction(self):
-        expr = '<% ctx().foobar ctx().foo.get(bar) ctx().fu.bar ctx().fu.bar[0] %>'
+        expr = '<%ctx().fubar ctx().foobar ctx().foo.get(bar) ctx().fu.bar ctx().foobaz.bar[0] %>'
 
         expected_vars = [
             'ctx().foobar',
+            'ctx().foobaz.bar[0]',
             'ctx().foo.get(bar)',
-            'ctx().fu.bar',
-            'ctx().fu.bar[0]'
+            'ctx().fubar',
+            'ctx().fu.bar'
         ]
 
         self.assertListEqual(

--- a/orquesta/tests/unit/expressions/test_yaql_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_yaql_ctx_by_function_arg.py
@@ -23,7 +23,7 @@ class YAQLVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         super(YAQLVariableExtractionTest, cls).setUpClass()
 
     def test_empty_extraction(self):
-        expr = '<% just_text and $not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') %>'
+        expr = '<% just_text and $not_a_var and notctx(foo) and notctx("bar") and notctx(\'fu\') %>'
 
         self.assertListEqual([], self.evaluator.extract_vars(expr))
 

--- a/orquesta/tests/unit/expressions/test_yaql_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_yaql_ctx_by_function_arg.py
@@ -23,7 +23,7 @@ class YAQLVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         super(YAQLVariableExtractionTest, cls).setUpClass()
 
     def test_empty_extraction(self):
-        expr = '<% just_text and $not_a_var %>'
+        expr = '<% just_text and $not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') %>'
 
         self.assertListEqual([], self.evaluator.extract_vars(expr))
 
@@ -82,13 +82,14 @@ class YAQLVariableExtractionTest(test_base.ExpressionEvaluatorTest):
         self.assertListEqual(expected_vars, self.evaluator.extract_vars(expr))
 
     def test_multiple_vars_extraction(self):
-        expr = '<% ctx(foobar) ctx(foo).get(bar) ctx(fu).bar ctx(fu).bar[0] %>'
+        expr = '<%ctx(fubar) ctx(foobar) ctx(foo).get(bar) ctx(fu).bar ctx(foobaz).bar[0] %>'
 
         expected_vars = [
             'ctx(foobar)',
+            'ctx(foobaz).bar[0]',
             'ctx(foo).get(bar)',
-            'ctx(fu).bar',
-            'ctx(fu).bar[0]'
+            'ctx(fubar)',
+            'ctx(fu).bar'
         ]
 
         self.assertListEqual(


### PR DESCRIPTION
The ctx() method returns a dict and there are use cases where users call supported methods on the dict such as keys(), values(), and get().  The vars extraction would return false positives on these function calls. The regular expressions to extract variables from expressions is refactored to ignore these dict related function calls directly on ctx(). Fixes https://github.com/StackStorm/st2/issues/4866.