### PR TITLE
Simplify Jinja expression context regexes

### DIFF
--- a/orquesta/expressions/jinja.py
+++ b/orquesta/expressions/jinja.py
@@ -54,22 +54,22 @@ class JinjaEvaluator(expr_base.Evaluator):
     _regex_pattern = '{{.*?}}'
     _regex_parser = re.compile(_regex_pattern)
 
-    _regex_ctx_pattern = r'[a-zA-Z0-9_\'"\.\[\]\(\)]*'
-    _regex_ctx_patterns = [
-        r'^ctx\(\)\.%s' % _regex_ctx_pattern,                                # line start ctx().*
-        r'^ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern),     # line start ctx(*).*
-        r'[\s]ctx\(\)\.%s' % _regex_ctx_pattern,                             # whitespace ctx().*
-        r'[\s]ctx\([\'|"]?{0}[\'|"]?\)[\.{0}]?'.format(_regex_ctx_pattern)   # whitespace ctx(*).*
-    ]
-    _regex_ctx_var = r'.*?(%s).*?' % '|'.join(_regex_ctx_patterns)
-    _regex_ctx_var_parser = re.compile(_regex_ctx_var)
+    _regex_reference_pattern = r'[][a-zA-Z0-9_\'"\.()]*'
+    # match any of:
+    #   word boundary ctx(*)
+    #   word boundary ctx()*
+    #   word boundary ctx().*
+    #   word boundary ctx(*)*
+    #   word boundary ctx(*).*
+    _regex_ctx_pattern = r'\bctx\([\'"]?{0}[\'"]?\)\.?{0}'.format(_regex_reference_pattern)
+    _regex_ctx_var_parser = re.compile(_regex_ctx_pattern)
 
-    _regex_var = r'[a-zA-Z0-9_\-]+'
+    _regex_var = r'[a-zA-Z0-9_-]+'
     _regex_var_extracts = [
-        r'(?<=^ctx\(\)\.)(\b%s\b)(?!\()\.?' % _regex_var,                   # extract x in ctx().x
-        r'(?<=^ctx\()(\b%s\b)(?=\))\.?' % _regex_var,                       # extract x in ctx(x)
-        r'(?<=^ctx\(\')(\b%s\b)(?=\'\))\.?' % _regex_var,                   # extract x in ctx('x')
-        r'(?<=^ctx\(")(\b%s\b)(?="\))\.?' % _regex_var                      # extract x in ctx("x")
+        r'(?<=\bctx\(\)\.)({})\b(?!\()\.?'.format(_regex_var),              # extract x in ctx().x
+        r'(?:\bctx\(({})\))'.format(_regex_var),                            # extract x in ctx(x)
+        r'(?:\bctx\(\'({})\'\))'.format(_regex_var),                        # extract x in ctx('x')
+        r'(?:\bctx\("({})"\))'.format(_regex_var)                           # extract x in ctx("x")
     ]
 
     _block_delimiter = '{%}'

--- a/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_dot_notation.py
+++ b/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_dot_notation.py
@@ -19,7 +19,9 @@ from orquesta.tests.unit import base as test_base
 class JinjaFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest):
 
     def test_empty_extraction(self):
-        expr = '{{ just_text and _not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') }}'
+        expr = (
+            '{{ just_text and _not_a_var and fooctx(foo) and fooctx("bar") and fooctx(\'fu\') '
+            'and ctx(). and ctx().() and ctx().-foobar and ctx().foobar() }}')
 
         self.assertListEqual([], expr_base.extract_vars(expr))
 

--- a/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_function_arg.py
+++ b/orquesta/tests/unit/expressions/test_facade_jinja_ctx_by_function_arg.py
@@ -23,7 +23,7 @@ class JinjaFacadeVariableExtractionTest(test_base.ExpressionFacadeEvaluatorTest)
             '{{ just_text and $not_a_var and '
             'notctx(foo) and notctx("bar") and notctx(\'fu\') '
             'ctx("foo\') and ctx(\'foo") and ctx(foo") and '
-            'ctx("foo) and ctx(foo\') and ctx(\'foo) }}'
+            'ctx("foo) and ctx(foo\') and ctx(\'foo) and ctx(-foobar) }}'
         )
 
         self.assertListEqual([], expr_base.extract_vars(expr))


### PR DESCRIPTION
This PR cleans up some of the regexes that are used to recognize context references and extract variable names. I also added a few more strings to the tests.

I can do some further cleanup, but it would make the regexes a lot more complicated to understand (but probably slightly faster to execute).