### PR TITLE
Add make command to publish package to pypi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,11 @@ livedocs: reqs
 package:
 	rm -rf $(PKGDISTDIR)
 	rm -rf $(PKGBUILDDIR)
-	$(PY3) setup.py sdist bdist_wheel
+	$(VENV_DIR)/bin/python setup.py sdist bdist_wheel
+
+.PHONY: publish
+publish: package
+	$(VENV_DIR)/bin/python -m twine upload dist/*
 
 .PHONY: all
 all: clean reqs schemas check package

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,4 +7,5 @@ nose
 nosexcover
 pep8>=1.6.0,<1.7
 pylint>=2.5.2,<2.6
+twine
 unittest2


### PR DESCRIPTION
Add twine to requirements file. Add make command to run twine to publish package to pypi.