### PR TITLE
Remove flags from regex parts for inline parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Fixed
 -----
 
 * Fix the custom flake8 extensions to check import statements. (bug fix)
+* Fix the deprecation warning that flags are not at the start of the expression. (bug fix)
 
 1.2.0
 -----

--- a/orquesta/utils/parameters.py
+++ b/orquesta/utils/parameters.py
@@ -24,8 +24,8 @@ REGEX_VALUE_IN_QUOTES = r"\"[^\"]*\"\s*"
 REGEX_VALUE_IN_APOSTROPHES = r"'[^']*'\s*"
 REGEX_FLOATING_NUMBER = r"[-]?\d*\.\d+"
 REGEX_INTEGER = r"[-]?\d+"
-REGEX_TRUE = r"(?i)true"
-REGEX_FALSE = r"(?i)false"
+REGEX_TRUE = r"(?i:true)" if six.PY3 else r"(?i)true"
+REGEX_FALSE = r"(?i:false)" if six.PY3 else r"(?i)false"
 REGEX_NULL = r"null"
 
 # REGEX_FLOATING_NUMBER must go before REGEX_INTEGER


### PR DESCRIPTION
The "(?i)" flag from regex parts used to build the expression for checking inline parameters results in deprecation warning from python3 regex module. The regex change here avoids the deprecation warning that flags are not at the start of the expression.