### PR TITLE
Add constructor in YAML SafeLoader to check duplicate keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Fixed
 ~~~~~
 
 * Fix unreachable join when an inbound task fails as defined in the task transition. (bug fix)
+* Throw exception if YAML of workflow definition contains duplicate keys (i.e. task name). (bug fix)
 
 1.3.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,8 @@ Fixed
 ~~~~~
 
 * Fix unreachable join when an inbound task fails as defined in the task transition. (bug fix)
-* Throw exception if YAML of workflow definition contains duplicate keys (i.e. task name). (bug fix)
+* Throw exception if the workflow definition that is written in YAML contains duplicate keys
+  (i.e. task name). (bug fix)
 
 1.3.0
 -----

--- a/orquesta/specs/base.py
+++ b/orquesta/specs/base.py
@@ -20,7 +20,6 @@ import jsonschema
 import logging
 import re
 import six
-import yaml
 
 from orquesta import exceptions as exc
 from orquesta.expressions import base as expr_base
@@ -29,6 +28,7 @@ from orquesta.utils import expression as expr_util
 from orquesta.utils import parameters as args_util
 from orquesta.utils import schema as schema_util
 from orquesta.utils import strings as str_util
+from orquesta.utils import yml as yaml_util
 
 
 LOG = logging.getLogger(__name__)
@@ -121,7 +121,7 @@ class Spec(object):
             raise ValueError("The spec cannot be type of None.")
 
         self.spec = (
-            yaml.safe_load(spec)
+            yaml_util.safe_load(spec)
             if not isinstance(spec, dict) and not isinstance(spec, list)
             else spec
         )

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -16,7 +16,6 @@
 import logging
 import six
 from six.moves import queue
-import yaml
 
 from orquesta import events
 from orquesta import exceptions as exc
@@ -27,6 +26,7 @@ from orquesta.utils import context as ctx_util
 from orquesta.utils import dictionary as dict_util
 from orquesta.utils import jsonify as json_util
 from orquesta.utils import parameters as args_util
+from orquesta.utils import yml as yaml_util
 
 
 LOG = logging.getLogger(__name__)
@@ -610,7 +610,7 @@ class WorkflowSpec(native_v1_specs.Spec):
             raise ValueError("The spec cannot be type of None.")
 
         spec = (
-            yaml.safe_load(spec)
+            yaml_util.safe_load(spec)
             if not isinstance(spec, dict) and not isinstance(spec, list)
             else spec
         )

--- a/orquesta/tests/hacking/import_aliases_rule.py
+++ b/orquesta/tests/hacking/import_aliases_rule.py
@@ -1,3 +1,4 @@
+# Copyright 2021 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,6 +54,7 @@ REQS = {
     "orquesta.utils.schema": "schema_util",
     "orquesta.utils.specs": "spec_util",
     "orquesta.utils.strings": "str_util",
+    "orquesta.utils.yml": "yaml_util",
 }
 
 

--- a/orquesta/tests/unit/specs/native/test_workflow_spec_validate.py
+++ b/orquesta/tests/unit/specs/native/test_workflow_spec_validate.py
@@ -1,3 +1,4 @@
+# Copyright 2021 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +15,9 @@
 
 import six
 
-from orquesta import exceptions as exc
+from orquesta.specs import loader as spec_loader
 from orquesta.tests.unit.specs.native import base as test_base
+from orquesta.utils import specs as spec_util
 
 
 class WorkflowSpecValidationTest(test_base.OrchestraWorkflowSpecTest):
@@ -489,11 +491,23 @@ class WorkflowSpecValidationTest(test_base.OrchestraWorkflowSpecTest):
                     do: task1
         """
 
+        expected_error = 'Failed to load workflow definition because found duplicate key "task1"'
+
         assertRaisesRegex = self.assertRaisesRegex if six.PY3 else self.assertRaisesRegexp
 
         assertRaisesRegex(
-            exc.WorkflowInspectionError,
-            "Workflow definition failed inspection.",
-            self.instantiate,
+            ValueError,
+            expected_error,
+            spec_util.instantiate,
+            self.spec_module_name,
+            wf_def,
+        )
+
+        spec_module = spec_loader.get_spec_module(self.spec_module_name)
+
+        assertRaisesRegex(
+            ValueError,
+            expected_error,
+            spec_module.instantiate,
             wf_def,
         )

--- a/orquesta/utils/specs.py
+++ b/orquesta/utils/specs.py
@@ -74,8 +74,10 @@ def instantiate(spec_type, definition):
     if isinstance(definition, six.string_types):
         try:
             definition = yaml.safe_load(definition)
-        except constructor.ConstructorError as e:
-            raise exc.WorkflowInspectionError([e])
+        except constructor.ConstructorError as yex:
+            raise exc.WorkflowInspectionError([yex])
+        except Exception as ex:
+            raise ex
 
     if not isinstance(definition, dict):
         raise ValueError("Unable to convert workflow definition into dict.")

--- a/orquesta/utils/specs.py
+++ b/orquesta/utils/specs.py
@@ -1,3 +1,4 @@
+# Copyright 2021 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,57 +15,11 @@
 
 import logging
 import six
-import yaml
 
-try:
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
-
-from yaml import constructor
-from yaml import nodes
-
-from orquesta import exceptions as exc
 from orquesta.specs import loader as spec_loader
-
+from orquesta.utils import yml as yaml_util
 
 LOG = logging.getLogger(__name__)
-
-
-# Custom YAML loader that throw an exception on duplicate key.
-# Credit: https://gist.github.com/pypt/94d747fe5180851196eb
-class UniqueKeyLoader(Loader):
-    def construct_mapping(self, node, deep=False):
-        if not isinstance(node, nodes.MappingNode):
-            raise constructor.ConstructorError(
-                None, None, "expected a mapping node, but found %s" % node.id, node.start_mark
-            )
-        mapping = {}
-        for key_node, value_node in node.value:
-            key = self.construct_object(key_node, deep=deep)
-            try:
-                hash(key)
-            except TypeError as exc:
-                raise constructor.ConstructorError(
-                    "while constructing a mapping",
-                    node.start_mark,
-                    "found unacceptable key (%s)" % exc,
-                    key_node.start_mark,
-                )
-            # check for duplicate keys
-            if key in mapping:
-                raise constructor.ConstructorError('found duplicate key "%s"' % key_node.value)
-            value = self.construct_object(value_node, deep=deep)
-            mapping[key] = value
-        return mapping
-
-
-# Add UniqueKeyLoader to the yaml SafeLoader so it is invoked by safe_load.
-yaml.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-    UniqueKeyLoader.construct_mapping,
-    Loader=yaml.SafeLoader,
-)
 
 
 def instantiate(spec_type, definition):
@@ -72,12 +27,7 @@ def instantiate(spec_type, definition):
         raise ValueError("Workflow definition is empty.")
 
     if isinstance(definition, six.string_types):
-        try:
-            definition = yaml.safe_load(definition)
-        except constructor.ConstructorError as yex:
-            raise exc.WorkflowInspectionError([yex])
-        except Exception as ex:
-            raise ex
+        definition = yaml_util.safe_load(definition)
 
     if not isinstance(definition, dict):
         raise ValueError("Unable to convert workflow definition into dict.")

--- a/orquesta/utils/specs.py
+++ b/orquesta/utils/specs.py
@@ -16,10 +16,55 @@ import logging
 import six
 import yaml
 
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+from yaml import constructor
+from yaml import nodes
+
+from orquesta import exceptions as exc
 from orquesta.specs import loader as spec_loader
 
 
 LOG = logging.getLogger(__name__)
+
+
+# Custom YAML loader that throw an exception on duplicate key.
+# Credit: https://gist.github.com/pypt/94d747fe5180851196eb
+class UniqueKeyLoader(Loader):
+    def construct_mapping(self, node, deep=False):
+        if not isinstance(node, nodes.MappingNode):
+            raise constructor.ConstructorError(
+                None, None, "expected a mapping node, but found %s" % node.id, node.start_mark
+            )
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                hash(key)
+            except TypeError as exc:
+                raise constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found unacceptable key (%s)" % exc,
+                    key_node.start_mark,
+                )
+            # check for duplicate keys
+            if key in mapping:
+                raise constructor.ConstructorError('found duplicate key "%s"' % key_node.value)
+            value = self.construct_object(value_node, deep=deep)
+            mapping[key] = value
+        return mapping
+
+
+# Add UniqueKeyLoader to the yaml SafeLoader so it is invoked by safe_load.
+yaml.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    UniqueKeyLoader.construct_mapping,
+    Loader=yaml.SafeLoader,
+)
 
 
 def instantiate(spec_type, definition):
@@ -27,7 +72,10 @@ def instantiate(spec_type, definition):
         raise ValueError("Workflow definition is empty.")
 
     if isinstance(definition, six.string_types):
-        definition = yaml.safe_load(definition)
+        try:
+            definition = yaml.safe_load(definition)
+        except constructor.ConstructorError as e:
+            raise exc.WorkflowInspectionError([e])
 
     if not isinstance(definition, dict):
         raise ValueError("Unable to convert workflow definition into dict.")
@@ -47,7 +95,9 @@ def instantiate(spec_type, definition):
     if not definition.keys():
         raise ValueError("Workflow definition contains no workflow.")
 
-    return spec_module.instantiate(definition)
+    spec = spec_module.instantiate(definition)
+
+    return spec
 
 
 def deserialize(data):

--- a/orquesta/utils/yml.py
+++ b/orquesta/utils/yml.py
@@ -1,0 +1,72 @@
+# Copyright 2021 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import yaml
+
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+from yaml import constructor
+from yaml import nodes
+
+LOG = logging.getLogger(__name__)
+
+
+# Custom YAML loader that throw an exception on duplicate key.
+# Credit: https://gist.github.com/pypt/94d747fe5180851196eb
+class UniqueKeyLoader(Loader):
+    def construct_mapping(self, node, deep=False):
+        if not isinstance(node, nodes.MappingNode):
+            raise constructor.ConstructorError(
+                None, None, "expected a mapping node, but found %s" % node.id, node.start_mark
+            )
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                hash(key)
+            except TypeError as exc:
+                raise constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found unacceptable key (%s)" % exc,
+                    key_node.start_mark,
+                )
+            # check for duplicate keys
+            if key in mapping:
+                raise constructor.ConstructorError('found duplicate key "%s"' % key_node.value)
+            value = self.construct_object(value_node, deep=deep)
+            mapping[key] = value
+        return mapping
+
+
+# Add UniqueKeyLoader to the yaml SafeLoader so it is invoked by safe_load.
+yaml.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    UniqueKeyLoader.construct_mapping,
+    Loader=yaml.SafeLoader,
+)
+
+
+# Use a separate method here for yaml safe_load to ensure UniqueKeyLoader is loaded.
+def safe_load(definition):
+    try:
+        return yaml.safe_load(definition)
+    except Exception as e:
+        # Reraise the exception as a ValueError since we do not need to
+        # propagate the additional args returned by the ConstructorError.
+        raise ValueError("Failed to load workflow definition because %s." % str(e))

--- a/orquesta/utils/yml.py
+++ b/orquesta/utils/yml.py
@@ -58,14 +58,17 @@ class UniqueKeyLoader(SafeLoader):
 yaml.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
     UniqueKeyLoader.construct_mapping,
-    Loader=yaml.SafeLoader,
+    Loader=SafeLoader,
 )
 
 
 # Use a separate method here for yaml safe_load to ensure UniqueKeyLoader is loaded.
 def safe_load(definition):
     try:
-        return yaml.safe_load(definition)
+        # The use of yaml.load and passing SafeLoader is the same as yaml.safe_load which
+        # makes the same call. The difference here is that we use CSafeLoader where possible
+        # to improve performance and yaml.safe_load uses the python implementation by default.
+        return yaml.load(definition, SafeLoader)
     except Exception as e:
         # Reraise the exception as a ValueError since we do not need to
         # propagate the additional args returned by the ConstructorError.

--- a/orquesta/utils/yml.py
+++ b/orquesta/utils/yml.py
@@ -16,9 +16,9 @@ import logging
 import yaml
 
 try:
-    from yaml import CLoader as Loader
+    from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import Loader
+    from yaml import SafeLoader
 
 from yaml import constructor
 from yaml import nodes
@@ -28,7 +28,7 @@ LOG = logging.getLogger(__name__)
 
 # Custom YAML loader that throw an exception on duplicate key.
 # Credit: https://gist.github.com/pypt/94d747fe5180851196eb
-class UniqueKeyLoader(Loader):
+class UniqueKeyLoader(SafeLoader):
     def construct_mapping(self, node, deep=False):
         if not isinstance(node, nodes.MappingNode):
             raise constructor.ConstructorError(


### PR DESCRIPTION
Add custom constructor in YAML SafeLoader to throw exception if there are duplicate keys in the YAML for the workflow definition. Fixes https://github.com/StackStorm/orquesta/issues/147.