### PR TITLE
Add python3.8 support to tests using tox-gh-actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,19 +11,22 @@ on:
     - cron: '0 6 * * 1'
 
 jobs:
-  py36:
+  tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.8"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: "${{ matrix.python-version }}"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox
-      - name: Run tox
+          pip install tox tox-gh-actions
+      - name: "Run tox for ${{ matrix.python-version }}"
         run: |
           tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,12 @@
 [tox]
-envlist = py36,pep8,docs
+envlist = py36,py38,pep8,docs
 minversion = 1.6
 skipsdist = True
+
+[gh-actions]
+python =
+    3.6: py36,pep8,docs
+    3.8: py38
 
 [testenv]
 usedevelop = True
@@ -12,7 +17,6 @@ commands =
     nosetests -sv --with-xcoverage --cover-package=orquesta orquesta.tests
 
 [testenv:pep8]
-basepython = python3.6
 deps =
     -r{toxinidir}/requirements-test.txt
 commands =
@@ -21,7 +25,6 @@ commands =
     black orquesta bin setup.py -l 100 --check
 
 [testenv:docs]
-basepython = python3.6
 deps =
     -r{toxinidir}/requirements-docs.txt
 commands =


### PR DESCRIPTION
This PR adds Python3.8 support to orquesta testing as part of the Ubuntu 20.04 support work https://github.com/StackStorm/discussions/issues/68