### PR TITLE
upgrade to latest networkx to allow running on py 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,13 @@ target/
 
 # Virtual Environments
 .venv
+venv/
 
 # Temporary Files
 *.swp
 
 # Visual Studio Code
 .vscode/
+
+# Pycharm
+.idea/

--- a/orquesta/graphing.py
+++ b/orquesta/graphing.py
@@ -53,8 +53,8 @@ class WorkflowGraph(object):
     @staticmethod
     def get_root_nodes(graph):
         nodes = [
-            {"id": n, "name": graph.node[n].get("name", n)}
-            for n, d in graph.in_degree().items()
+            {"id": n, "name": graph.nodes[n].get("name", n)}
+            for n, d in dict(graph.in_degree()).items()
             if d == 0
         ]
 
@@ -80,7 +80,7 @@ class WorkflowGraph(object):
             raise exc.InvalidTask(task_id)
 
         task = {"id": task_id}
-        task.update(json_util.deepcopy(self._graph.node[task_id]))
+        task.update(json_util.deepcopy(self._graph.nodes[task_id]))
 
         return task
 
@@ -102,7 +102,7 @@ class WorkflowGraph(object):
             raise exc.InvalidTask(task_id)
 
         for key, value in six.iteritems(kwargs):
-            self._graph.node[task_id][key] = value
+            self._graph.nodes[task_id][key] = value
 
     def has_transition(self, source, destination, **kwargs):
         edges = filter(

--- a/orquesta/tests/unit/conducting/test_workflow_conductor.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor.py
@@ -141,7 +141,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
         self.assertEqual(conductor.workflow_state.status, statuses.UNSET)
         self.assertEqual(conductor.get_workflow_status(), statuses.UNSET)
         self.assertIsInstance(conductor.graph, graphing.WorkflowGraph)
-        self.assertEqual(len(conductor.graph._graph.node), 5)
+        self.assertEqual(len(conductor.graph._graph.nodes), 5)
         self.assertIsInstance(conductor.workflow_state, conducting.WorkflowState)
 
     def test_init_with_inputs(self):
@@ -180,7 +180,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
         self.assertEqual(conductor.workflow_state.status, statuses.UNSET)
         self.assertEqual(conductor.get_workflow_status(), statuses.UNSET)
         self.assertIsInstance(conductor.graph, graphing.WorkflowGraph)
-        self.assertEqual(len(conductor.graph._graph.node), 5)
+        self.assertEqual(len(conductor.graph._graph.nodes), 5)
         self.assertIsInstance(conductor.workflow_state, conducting.WorkflowState)
 
     def test_init_with_partial_inputs(self):
@@ -221,7 +221,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
         self.assertEqual(conductor.workflow_state.status, statuses.UNSET)
         self.assertEqual(conductor.get_workflow_status(), statuses.UNSET)
         self.assertIsInstance(conductor.graph, graphing.WorkflowGraph)
-        self.assertEqual(len(conductor.graph._graph.node), 5)
+        self.assertEqual(len(conductor.graph._graph.nodes), 5)
         self.assertIsInstance(conductor.workflow_state, conducting.WorkflowState)
 
     def test_init_with_context(self):
@@ -263,7 +263,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
         self.assertEqual(conductor.workflow_state.status, statuses.UNSET)
         self.assertEqual(conductor.get_workflow_status(), statuses.UNSET)
         self.assertIsInstance(conductor.graph, graphing.WorkflowGraph)
-        self.assertEqual(len(conductor.graph._graph.node), 5)
+        self.assertEqual(len(conductor.graph._graph.nodes), 5)
         self.assertIsInstance(conductor.workflow_state, conducting.WorkflowState)
 
     def test_serialization(self):
@@ -296,7 +296,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
 
         self.assertIsInstance(conductor.spec, native_specs.WorkflowSpec)
         self.assertIsInstance(conductor.graph, graphing.WorkflowGraph)
-        self.assertEqual(len(conductor.graph._graph.node), 5)
+        self.assertEqual(len(conductor.graph._graph.nodes), 5)
         self.assertEqual(conductor.get_workflow_status(), statuses.SUCCEEDED)
         self.assertIsInstance(conductor.workflow_state, conducting.WorkflowState)
         self.assertEqual(len(conductor.workflow_state.tasks), 5)
@@ -850,7 +850,7 @@ class WorkflowConductorTest(test_base.WorkflowConductorTest):
         self.assertIsInstance(conductor.spec, native_specs.WorkflowSpec)
         self.assertEqual(conductor.get_workflow_status(), statuses.RUNNING)
         self.assertIsInstance(conductor.graph, graphing.WorkflowGraph)
-        self.assertEqual(len(conductor.graph._graph.node), 5)
+        self.assertEqual(len(conductor.graph._graph.nodes), 5)
         self.assertIsInstance(conductor.workflow_state, conducting.WorkflowState)
         self.assertListEqual(conductor.log, expected_log_entries)
         self.assertListEqual(conductor.errors, expected_errors)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ chardet>=3.0.2,<4.0.0
 eventlet
 Jinja2>=2.8 # BSD License (3 clause)
 jsonschema!=2.5.0,<3.0.0,>=2.0.0 # MIT
-networkx>=1.10,<2.0
+networkx==2.5.1
 python-dateutil
 PyYAML>=3.1.0 # MIT
 six>=1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ chardet>=3.0.2,<4.0.0
 eventlet
 Jinja2>=2.8 # BSD License (3 clause)
 jsonschema!=2.5.0,<3.0.0,>=2.0.0 # MIT
-networkx==2.5.1
+networkx>=2.5.1,<3.0
 python-dateutil
 PyYAML>=3.1.0 # MIT
 six>=1.9.0


### PR DESCRIPTION
# Summary

Orquesta won't run on python 3.9+ because it currently has a dependency on  `networkx` version 1.11. It doesn't look like the 1.x version of `networkx` has received any updates in quite a while. In Python 3.9, the `gcd` function used by `networkx` was moved from `functions` to `math` package in the standard lib [as described here](https://stackoverflow.com/questions/66174862/import-error-cant-import-name-gcd-from-fractions). This PR updates orquesta to use the latest version of `networkx` which is currently 2.5.1.

The code has been modified where necessary and all tests are passing on my machine with Python 3.9.5. Let me know if there is anything else necessary. Thanks.