### PR TITLE
Optimise inspect and workflow graph generation logic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Fixed
 ~~~~~
 
 * Update jinja to use sandboxed environment. (bug fix)
+* Optimise inspect and workflow graph generation logic. (improvement)
+  Contributed by @yogeshgoyal26
 
 1.4.0
 -----

--- a/orquesta/composers/native.py
+++ b/orquesta/composers/native.py
@@ -43,7 +43,7 @@ class WorkflowComposer(comp_base.WorkflowComposer):
 
         q = queue.Queue()
         wf_graph = graphing.WorkflowGraph()
-        track_task = {}
+        track_splits = {}
 
         for task_name, condition, task_transition_item_idx in wf_spec.tasks.get_start_tasks():
             q.put((task_name, []))
@@ -90,9 +90,8 @@ class WorkflowComposer(comp_base.WorkflowComposer):
                 if not wf_graph.has_task(next_task_name) or not wf_spec.tasks.in_cycle(
                     next_task_name
                 ):
-                    # Track task and its splits, if superset is already added to queue
-                    # don't add them again
-                    existing_splits = track_task.get(next_task_name, {})
+                    # Track splits and if superset is already in queue then don't add them again
+                    existing_splits = track_splits.get(next_task_name, {})
                     if existing_splits:
                         new_splits = set(splits)
                         if not (
@@ -100,9 +99,9 @@ class WorkflowComposer(comp_base.WorkflowComposer):
                         ):
                             q.put((next_task_name, list(splits)))
                             existing_splits.update(new_splits)
-                            track_task[next_task_name] = existing_splits
+                            track_splits[next_task_name] = existing_splits
                     else:
-                        track_task[next_task_name] = set(splits)
+                        track_splits[next_task_name] = set(splits)
                         q.put((next_task_name, list(splits)))
 
                 crta = [condition] if condition else []

--- a/orquesta/composers/native.py
+++ b/orquesta/composers/native.py
@@ -43,6 +43,7 @@ class WorkflowComposer(comp_base.WorkflowComposer):
 
         q = queue.Queue()
         wf_graph = graphing.WorkflowGraph()
+        track_task = {}
 
         for task_name, condition, task_transition_item_idx in wf_spec.tasks.get_start_tasks():
             q.put((task_name, []))
@@ -89,7 +90,20 @@ class WorkflowComposer(comp_base.WorkflowComposer):
                 if not wf_graph.has_task(next_task_name) or not wf_spec.tasks.in_cycle(
                     next_task_name
                 ):
-                    q.put((next_task_name, list(splits)))
+                    # Track task and its splits, if superset is already added to queue
+                    # don't add them again
+                    existing_splits = track_task.get(next_task_name, {})
+                    if existing_splits:
+                        new_splits = set(splits)
+                        if not (
+                            existing_splits == new_splits or new_splits.issubset(existing_splits)
+                        ):
+                            q.put((next_task_name, list(splits)))
+                            existing_splits.update(new_splits)
+                            track_task[next_task_name] = existing_splits
+                    else:
+                        track_task[next_task_name] = set(splits)
+                        q.put((next_task_name, list(splits)))
 
                 crta = [condition] if condition else []
 

--- a/orquesta/composers/native.py
+++ b/orquesta/composers/native.py
@@ -91,18 +91,17 @@ class WorkflowComposer(comp_base.WorkflowComposer):
                     next_task_name
                 ):
                     # Track splits and if superset is already in queue then don't add them again
-                    existing_splits = track_splits.get(next_task_name, {})
+                    split_id = next_task_name
+                    existing_splits = track_splits.get(split_id, set())
                     if existing_splits:
                         new_splits = set(splits)
-                        if not (
-                            existing_splits == new_splits or new_splits.issubset(existing_splits)
-                        ):
+                        if not new_splits.issubset(existing_splits):
                             q.put((next_task_name, list(splits)))
                             existing_splits.update(new_splits)
-                            track_splits[next_task_name] = existing_splits
+                            track_splits[split_id] = existing_splits
                     else:
-                        track_splits[next_task_name] = set(splits)
                         q.put((next_task_name, list(splits)))
+                        track_splits[split_id] = set(splits)
 
                 crta = [condition] if condition else []
 

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -430,6 +430,7 @@ class TaskMappingSpec(native_v1_specs.MappingSpec):
         result = []
         staging = {}
         q = queue.Queue()
+        track_tasks = {}
 
         # Traverse the tasks spec and prep data for evaluation.
         for task_name, condition, task_transition_item_idx in self.get_start_tasks():
@@ -466,7 +467,20 @@ class TaskMappingSpec(native_v1_specs.MappingSpec):
 
             for next_task_name, condition, task_transition_item_idx in next_tasks:
                 if next_task_name not in staging or not self.in_cycle(next_task_name):
-                    q.put((task_name, next_task_name, list(splits)))
+                    # keep track of splits for task and its next task combination,
+                    # if superset is already added to queue, no need to add again
+                    existing_splits = track_tasks.get(task_name + "_" + next_task_name, {})
+                    if existing_splits:
+                        new_splits = set(splits)
+                        if not (
+                            existing_splits == new_splits or new_splits.issubset(existing_splits)
+                        ):
+                            q.put((task_name, next_task_name, list(splits)))
+                            existing_splits.update(new_splits)
+                            track_tasks[task_name + "_" + next_task_name] = existing_splits
+                    else:
+                        q.put((task_name, next_task_name, list(splits)))
+                        track_tasks[task_name + "_" + next_task_name] = set(splits)
 
         # Use the prepped data to identify tasks that are not reachable.
         for task_name, meta in six.iteritems(staging):
@@ -475,7 +489,7 @@ class TaskMappingSpec(native_v1_specs.MappingSpec):
                 continue
 
             for prev_task_name in meta["prev"]:
-                meta["reachable"] = meta["splits"] == staging[prev_task_name]["splits"]
+                meta["reachable"] = set(meta["splits"]) == set(staging[prev_task_name]["splits"])
 
                 if not meta["reachable"]:
                     msg = (

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -469,18 +469,17 @@ class TaskMappingSpec(native_v1_specs.MappingSpec):
                 if next_task_name not in staging or not self.in_cycle(next_task_name):
                     # Keep track of splits for task and its next task combination,
                     # if superset is already added to queue, then no need to add again.
-                    existing_splits = track_splits.get(task_name + "_" + next_task_name, {})
+                    split_id = task_name + "_" + next_task_name
+                    existing_splits = track_splits.get(split_id, set())
                     if existing_splits:
                         new_splits = set(splits)
-                        if not (
-                            existing_splits == new_splits or new_splits.issubset(existing_splits)
-                        ):
+                        if not new_splits.issubset(existing_splits):
                             q.put((task_name, next_task_name, list(splits)))
                             existing_splits.update(new_splits)
-                            track_splits[task_name + "_" + next_task_name] = existing_splits
+                            track_splits[split_id] = existing_splits
                     else:
                         q.put((task_name, next_task_name, list(splits)))
-                        track_splits[task_name + "_" + next_task_name] = set(splits)
+                        track_splits[split_id] = set(splits)
 
         # Use the prepped data to identify tasks that are not reachable.
         for task_name, meta in six.iteritems(staging):

--- a/orquesta/specs/native/v1/models.py
+++ b/orquesta/specs/native/v1/models.py
@@ -430,7 +430,7 @@ class TaskMappingSpec(native_v1_specs.MappingSpec):
         result = []
         staging = {}
         q = queue.Queue()
-        track_tasks = {}
+        track_splits = {}
 
         # Traverse the tasks spec and prep data for evaluation.
         for task_name, condition, task_transition_item_idx in self.get_start_tasks():
@@ -467,9 +467,9 @@ class TaskMappingSpec(native_v1_specs.MappingSpec):
 
             for next_task_name, condition, task_transition_item_idx in next_tasks:
                 if next_task_name not in staging or not self.in_cycle(next_task_name):
-                    # keep track of splits for task and its next task combination,
-                    # if superset is already added to queue, no need to add again
-                    existing_splits = track_tasks.get(task_name + "_" + next_task_name, {})
+                    # Keep track of splits for task and its next task combination,
+                    # if superset is already added to queue, then no need to add again.
+                    existing_splits = track_splits.get(task_name + "_" + next_task_name, {})
                     if existing_splits:
                         new_splits = set(splits)
                         if not (
@@ -477,10 +477,10 @@ class TaskMappingSpec(native_v1_specs.MappingSpec):
                         ):
                             q.put((task_name, next_task_name, list(splits)))
                             existing_splits.update(new_splits)
-                            track_tasks[task_name + "_" + next_task_name] = existing_splits
+                            track_splits[task_name + "_" + next_task_name] = existing_splits
                     else:
                         q.put((task_name, next_task_name, list(splits)))
-                        track_tasks[task_name + "_" + next_task_name] = set(splits)
+                        track_splits[task_name + "_" + next_task_name] = set(splits)
 
         # Use the prepped data to identify tasks that are not reachable.
         for task_name, meta in six.iteritems(staging):

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_performance.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_performance.py
@@ -100,7 +100,7 @@ class WorkflowConductorStressTest(test_base.WorkflowConductorTest):
         t2 = datetime.datetime.utcnow()
 
         delta = t2 - t1
-        self.assertLess(delta.seconds, 1)
+        self.assertLess(delta.seconds, 3)
 
 
 class WorkflowConductorWithItemsStressTest(test_base.WorkflowConductorWithItemsTest):

--- a/orquesta/tests/unit/conducting/test_workflow_conductor_performance.py
+++ b/orquesta/tests/unit/conducting/test_workflow_conductor_performance.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import random
 import string
 
@@ -73,6 +74,33 @@ class WorkflowConductorStressTest(test_base.WorkflowConductorTest):
         self.assertEqual(len(data), data_length)
         conductor = self._prep_conductor(1, inputs={"data": data}, status=statuses.RUNNING)
         conductor.deserialize(conductor.serialize())
+
+    def test_runtime_function_of_splits_count(self):
+        num_tasks = 25
+
+        wf_def = {"input": ["data"], "tasks": {}}
+
+        for i in range(1, num_tasks):
+            task_name = "t" + str(i)
+            next_task_name = "t" + str(i + 1)
+            next_next_task_name = "t" + str(i + 2)
+            transition = [
+                {"when": "<% succeeded() %>", "do": next_task_name},
+                {"when": "<% succeeded() %>", "do": next_next_task_name},
+            ]
+            wf_def["tasks"][task_name] = {"action": "core.noop", "next": transition}
+
+        wf_def["tasks"]["t%d" % num_tasks] = {"action": "core.noop"}
+        wf_def["tasks"]["t%d" % (num_tasks + 1)] = {"action": "core.noop"}
+
+        spec = native_specs.WorkflowSpec(wf_def)
+
+        t1 = datetime.datetime.utcnow()
+        self.assertDictEqual(spec.inspect(), {})
+        t2 = datetime.datetime.utcnow()
+
+        delta = t2 - t1
+        self.assertLess(delta.seconds, 1)
 
 
 class WorkflowConductorWithItemsStressTest(test_base.WorkflowConductorWithItemsTest):


### PR DESCRIPTION
Workflows which has many task or if multiple tasks are going to common task in the flow, execution of such workflows take lot of time in inspect and serialize of workflow definition.
In `st2common/services/workflows.py`

https://github.com/StackStorm/st2/blob/master/st2common/st2common/services/workflows.py#L230
```
    # Inspect the workflow spec.
    inspect(wf_spec, st2_ctx, raise_exception=True)
```

https://github.com/StackStorm/st2/blob/master/st2common/st2common/services/workflows.py#L255

   ```
 # Serialize the conductor which initializes some internal values.
    data = conductor.serialize()
```
Some of our workflows are very complex with many task and when-do conditions.Even in some workflows it was taking hours in conductor serialization.

**Proposed Solution:**
In inspect and conductor serialization, while adding the task and its splits to the queue also keep a separate track of task and its splits which are being added to the queue and refer to that track to check if current task and superset of splits is already added to queue or not, if not then add it otherwise skip that.
