### PR TITLE
Use Jinja sandboxed environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Development
+-----------
+
+Fixed
+~~~~~
+
+* Update jinja to use sandboxed environment. (bug fix)
+
 1.4.0
 -----
 

--- a/orquesta/expressions/jinja.py
+++ b/orquesta/expressions/jinja.py
@@ -20,6 +20,7 @@ import re
 import six
 
 import jinja2
+import jinja2.sandbox
 
 from orquesta import exceptions as exc
 from orquesta.expressions import base as expr_base
@@ -79,7 +80,7 @@ class JinjaEvaluator(expr_base.Evaluator):
     _regex_raw_block_pattern = "{% raw %}.*?{% endraw %}"
     _regex_raw_block_parser = re.compile(_regex_raw_block_pattern)
 
-    _jinja_env = jinja2.Environment(
+    _jinja_env = jinja2.sandbox.SandboxedEnvironment(
         undefined=jinja2.StrictUndefined, trim_blocks=True, lstrip_blocks=True
     )
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
-sphinx>=1.7.5,<1.8
+sphinx>=2.0
 sphinx-autobuild
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 chardet>=3.0.2,<4.0.0
 eventlet
-Jinja2>=2.8 # BSD License (3 clause)
+Jinja2>=2.11 # BSD License (3 clause)
 jsonschema!=2.5.0,<3.0.0,>=2.0.0 # MIT
 networkx>=2.5.1,<3.0
 python-dateutil


### PR DESCRIPTION
Use Jinja sandboxed environment, so that any templates that attempt to access insecure code will be rejected.