### PR TITLE
Pin networkx to versions lower than 2.6 which doesn't support Python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ chardet>=3.0.2,<4.0.0
 eventlet
 Jinja2>=2.11 # BSD License (3 clause)
 jsonschema!=2.5.0,<3.0.0,>=2.0.0 # MIT
-networkx>=2.5.1,<3.0
+# networkx v2.6 does not support Python3.6.  Update networkx to match st2
+networkx>=2.5.1,<2.6
 python-dateutil
 PyYAML>=3.1.0 # MIT
 six>=1.9.0


### PR DESCRIPTION
Update requirements to match st2 https://github.com/StackStorm/st2/pull/5376