### PR TITLE
add 'Initiating test spec' to process to make debugging clear

### DIFF
--- a/orquesta/commands/rehearsal.py
+++ b/orquesta/commands/rehearsal.py
@@ -25,7 +25,7 @@ LOG = logging.getLogger(__name__)
 
 def process(base_path, test_spec):
     fixture_path = "%s/%s" % (base_path, test_spec)
-    
+
     if not os.path.isfile(fixture_path):
         raise exc.WorkflowRehearsalError('The test spec "%s" does not exist.' % fixture_path)
     LOG.info('Initiating test spec "%s".' % fixture_path)

--- a/orquesta/commands/rehearsal.py
+++ b/orquesta/commands/rehearsal.py
@@ -25,10 +25,10 @@ LOG = logging.getLogger(__name__)
 
 def process(base_path, test_spec):
     fixture_path = "%s/%s" % (base_path, test_spec)
-
+    
     if not os.path.isfile(fixture_path):
         raise exc.WorkflowRehearsalError('The test spec "%s" does not exist.' % fixture_path)
-
+    LOG.info('Initiating test spec "%s".' % fixture_path)
     rehearsal = rehearsing.load_test_spec(fixture_path=test_spec, base_path=base_path)
     LOG.info('The test spec "%s" is successfully loaded.' % fixture_path)
 


### PR DESCRIPTION
When debugging an entire folder of workflow tests using the `-d` flag it is not clear which test fixture is causing spec errors.  This PR adds a log.info output line so that it is clear to the user which fixture caused a spec error.

```
2021-12-17 15:25:59,693 - INFO - The test spec "././workflow_tests//process_single.yaml" is successfully loaded.
2021-12-17 15:25:59,693 - INFO - Start test for workflow "./actions/workflows/process_single.yaml".
2021-12-17 15:25:59,725 - DEBUG - Task "initial_ticket__r0" is set to "running".
2021-12-17 15:25:59,726 - DEBUG - Applying action execution with "succeeded" status to task "initial_ticket__r0".
2021-12-17 15:25:59,735 - DEBUG - Task "initial_ticket__r0" is set to "succeeded".
2021-12-17 15:25:59,746 - DEBUG - Task "add_indicators_mitigate__r0" is identified to run next.
2021-12-17 15:25:59,750 - DEBUG - Task "add_indicators_mitigate__r0" is set to "running".
2021-12-17 15:25:59,750 - DEBUG - Applying action execution with "succeeded" status to task "add_indicators_mitigate__r0".
2021-12-17 15:25:59,751 - DEBUG - Task "add_indicators_mitigate__r0" is set to "succeeded".
2021-12-17 15:25:59,754 - DEBUG - The workflow completed with status "succeeded".
2021-12-17 15:25:59,754 - DEBUG - The workflow output with "{'parent_execution_id': 'xxx', 'message': ''}".
2021-12-17 15:25:59,754 - DEBUG - The workflow completed with no errors.
2021-12-17 15:25:59,754 - DEBUG - Comparing with expected task execution sequence.
2021-12-17 15:25:59,754 - DEBUG - Comparing with expected workflow route(s).
2021-12-17 15:25:59,754 - DEBUG - Comparing with expected workflow status.
2021-12-17 15:25:59,754 - DEBUG - Comparing with expected workflow output.
2021-12-17 15:25:59,755 - INFO - Completed running test and the workflow execution matches the test spec.
2021-12-17 15:26:00,065 - ERROR - Task "mitigate" does not exist. <---- this error is NOT from the above fixture process_single.yaml'
```

The arrow above shows the point of confusion.  This error is actually from a different test fixture.  It is not from process_single.yaml