### PR TITLE
ability to disable recursively evaluation of jinja and yaql expressions.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+1.5.1
+-----
+Added
+~~~~~
+
+* Ability to disable the recursively evaluation of jinja and yaql expressions, by setting the environment variable ``ENABLE_RECURSIVELY_EVALUATION`` to ``false``.
+  Contributed by @moradf90
+
+
 1.5.0
 -----
 
@@ -138,7 +147,7 @@ Added
 ~~~~~
 
 * Add flake8 extension to restrict import alias. (improvement)
-* Add developer docs on getting started, testing, and StackStorm integration. (improvement) 
+* Add developer docs on getting started, testing, and StackStorm integration. (improvement)
 
 Changed
 ~~~~~~~
@@ -168,7 +177,7 @@ Added
 Fixed
 ~~~~~
 
-* Add sleep in while loop for composing execution graph to spread out cpu spike. (improvement) 
+* Add sleep in while loop for composing execution graph to spread out cpu spike. (improvement)
 * Value in quotes in shorthand publish should be evaluated as string type. Fixes #130 (bug fix)
 * Fix interpretation of boolean value in shorthand format of publish. Fixes #119 (bug fix)
 * Update YAQL section in docs on use of "=>" for named parameters in function calls. Closes #124

--- a/orquesta/__init__.py
+++ b/orquesta/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/orquesta/expressions/yql.py
+++ b/orquesta/expressions/yql.py
@@ -62,7 +62,9 @@ class YAQLEvaluator(expr_base.Evaluator):
     #   word boundary ctx().*
     #   word boundary ctx(*)*
     #   word boundary ctx(*).*
-    _regex_ctx_pattern = r'\bctx\([\'"]?{0}[\'"]?\)\.?{0}'.format(_regex_ctx_ref_pattern)
+    _regex_ctx_pattern = r'\bctx\([\'"]?{0}[\'"]?\)\.?{0}'.format(
+        _regex_ctx_ref_pattern
+    )
     _regex_ctx_var_parser = re.compile(_regex_ctx_pattern)
 
     _regex_var = r"[a-zA-Z0-9_-]+"
@@ -84,7 +86,9 @@ class YAQLEvaluator(expr_base.Evaluator):
         # Some yaql expressions (e.g. distinct()) refer to hash value of variable.
         # But some built-in Python type values (e.g. list and dict) don't have __hash__() method.
         # The convert_input_data method parses specified variable and convert it to hashable one.
-        if isinstance(data, yaql_utils.SequenceType) or isinstance(data, yaql_utils.MappingType):
+        if isinstance(data, yaql_utils.SequenceType) or isinstance(
+            data, yaql_utils.MappingType
+        ):
             ctx["__vars"] = yaql_utils.convert_input_data(data)
         else:
             ctx["__vars"] = data or {}
@@ -144,7 +148,10 @@ class YAQLEvaluator(expr_base.Evaluator):
                 if inspect.isgenerator(result):
                     result = list(result)
 
-                if isinstance(result, six.string_types):
+                if (
+                    isinstance(result, six.string_types)
+                    and cls.enable_recursively_evaluation()
+                ):
                     result = cls.evaluate(result, data)
 
                 if len(exprs) > 1 or len(output) > len(expr):
@@ -158,7 +165,9 @@ class YAQLEvaluator(expr_base.Evaluator):
             raise YaqlEvaluationException(msg % (error, expr))
         except (yaql_exc.YaqlException, ValueError, TypeError) as e:
             msg = "Unable to evaluate expression '%s'. %s: %s"
-            raise YaqlEvaluationException(msg % (expr, e.__class__.__name__, str(e).strip("'")))
+            raise YaqlEvaluationException(
+                msg % (expr, e.__class__.__name__, str(e).strip("'"))
+            )
         except Exception as e:
             msg = "Unable to evaluate expression '%s'. %s: %s"
             raise YaqlEvaluationException(msg % (expr, e.__class__.__name__, str(e)))


### PR DESCRIPTION
add the ability to disable the feature of recursively evaluation of jinja and yaql expressions by setting the environment variable ``ENABLE_RECURSIVELY_EVALUATION`` to ``false``.