### PR TITLE
update builtin collections imports to be forward-compatible with Python3.10+

### DIFF
--- a/orquesta/expressions/functions/workflow.py
+++ b/orquesta/expressions/functions/workflow.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
+import collections.abc
 
 from orquesta import constants
 from orquesta import exceptions as exc
@@ -118,7 +118,7 @@ def item_(context, key=None):
         return current_item
 
     if not isinstance(current_item, collections.abc.Mapping):
-        raise exc.ExpressionEvaluationException("Item is not type of collections.Mapping.")
+        raise exc.ExpressionEvaluationException("Item is not type of collections.abc.Mapping.")
 
     if key not in current_item:
         raise exc.ExpressionEvaluationException('Item does not have key "%s".' % key)

--- a/orquesta/expressions/functions/workflow.py
+++ b/orquesta/expressions/functions/workflow.py
@@ -117,7 +117,7 @@ def item_(context, key=None):
     if not key:
         return current_item
 
-    if not isinstance(current_item, collections.Mapping):
+    if not isinstance(current_item, collections.abc.Mapping):
         raise exc.ExpressionEvaluationException("Item is not type of collections.Mapping.")
 
     if key not in current_item:

--- a/orquesta/specs/base.py
+++ b/orquesta/specs/base.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
+import collections.abc
 import inspect
 import json
 import jsonschema

--- a/orquesta/specs/base.py
+++ b/orquesta/specs/base.py
@@ -613,7 +613,7 @@ class MappingSpec(Spec):
         raise NotImplementedError()
 
 
-class SequenceSpec(Spec, collections.MutableSequence):
+class SequenceSpec(Spec, collections.abc.MutableSequence):
     def __init__(self, spec, name=None, member=False):
         super(SequenceSpec, self).__init__(spec, name=name, member=member)
 


### PR DESCRIPTION
Python 3.10 removes the deprecated aliases to the Collections abstract base classes, which was done in Python 3.3
Python3.10 Changelog: 
> Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) from the [collections](https://docs.python.org/3/library/collections.html#module-collections) module. (Contributed by Victor Stinner in [bpo-37324](https://bugs.python.org/issue?@action=redirect&bpo=37324).)

This change refactors the imports in 2 files that were still using this deprecated import style to one that is more globally supported.

https://docs.python.org/3/whatsnew/3.10.html#removed