### PR TITLE
Prepare for orquesta v1.6.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-In Development
---------------
+1.6.0
+-----
 
 Changed
 ~~~~~~~
@@ -13,9 +13,13 @@ Changed
   Contributed by @AndroxxTraxxon
 * Add Python versions 3.9, 3.10, and 3.11 to the test matrix
   Contributed by @AndroxxTraxxon
-* Update networkx >=2.6 for Python 3.8 to fix insecure deserialization #255 (improvement)
+
+Fixed
+~~~~~
+
+* Update networkx >=2.6 for Python 3.8 to fix insecure deserialization #255 (security fix)
   Contributed by @Stealthii
-* Update jsonschema requirements to allow 3.2 (improvement)
+* Update jsonschema requirements to allow 3.2 (security fix)
   Contributed by @james-bellamy
 
 1.5.0

--- a/orquesta/__init__.py
+++ b/orquesta/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"


### PR DESCRIPTION
Preparing a release of orquesta for st2. Update orquesta version from 1.5.0 to 1.6.0.
