### PR TITLE
Update dependencies (v3.9)

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ jsonschema!=2.5.0,>=2.0.0,<=3.2 # MIT
 # networkx v2.6 does not support Python3.6.  Update networkx to match st2
 networkx==3.1
 python-dateutil
-PyYAML>=3.1.0 # MIT
-six>=1.9.0
+PyYAML==6.0.1
+six>=1.16.0
 stevedore>=1.3.0 # Apache-2.0
 ujson>=1.35 # BSD License
 yaql>=1.1.0 # Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ eventlet
 Jinja2>=2.11 # BSD License (3 clause)
 jsonschema!=2.5.0,>=2.0.0,<=3.2 # MIT
 # networkx v2.6 does not support Python3.6.  Update networkx to match st2
-networkx==3.2.1
+networkx==3.1
 python-dateutil
 PyYAML>=3.1.0 # MIT
 six>=1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ PyYAML==6.0.1
 six>=1.16.0
 stevedore==5.1.0 # Apache-2.0
 ujson==5.8.0 # BSD License
-yaql>=1.1.0 # Apache-2.0
+yaql==2.0.0 # Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 chardet==5.2.0
 eventlet
-Jinja2>=2.11 # BSD License (3 clause)
+Jinja2==3.1.2 # BSD License (3 clause)
 jsonschema!=2.5.0,>=2.0.0,<=3.2 # MIT
 # networkx v2.6 does not support Python3.6.  Update networkx to match st2
 networkx==3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ chardet==5.2.0
 eventlet
 Jinja2==3.1.2 # BSD License (3 clause)
 jsonschema!=2.5.0,>=2.0.0,<=3.2 # MIT
-# networkx v2.6 does not support Python3.6.  Update networkx to match st2
 networkx==3.1
 python-dateutil
 PyYAML==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-chardet>=3.0.2,<4.0.0
+chardet==5.2.0
 eventlet
 Jinja2>=2.11 # BSD License (3 clause)
 jsonschema!=2.5.0,>=2.0.0,<=3.2 # MIT

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ networkx==3.1
 python-dateutil
 PyYAML==6.0.1
 six>=1.16.0
-stevedore>=1.3.0 # Apache-2.0
+stevedore==5.1.0 # Apache-2.0
 ujson>=1.35 # BSD License
 yaql>=1.1.0 # Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 chardet==5.2.0
 eventlet
 Jinja2==3.1.2 # BSD License (3 clause)
-jsonschema==4.20.0 # MIT
+jsonschema!=2.5.0,>=2.0.0,<=3.2 # MIT
+# jsonschema newer version not working: ImportError: cannot import name '_validators' from 'jsonschema' (/home/hombergerpadm/st2-python-keyczar/virtualenv/lib/python3.8/site-packages/jsonschema/__init__.py
 networkx==3.1
 python-dateutil
 PyYAML==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ python-dateutil
 PyYAML==6.0.1
 six>=1.16.0
 stevedore==5.1.0 # Apache-2.0
-ujson>=1.35 # BSD License
+ujson==5.8.0 # BSD License
 yaql>=1.1.0 # Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 chardet==5.2.0
 eventlet
 Jinja2==3.1.2 # BSD License (3 clause)
-jsonschema!=2.5.0,>=2.0.0,<=3.2 # MIT
+jsonschema==4.20.0 # MIT
 networkx==3.1
 python-dateutil
 PyYAML==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ eventlet
 Jinja2>=2.11 # BSD License (3 clause)
 jsonschema!=2.5.0,>=2.0.0,<=3.2 # MIT
 # networkx v2.6 does not support Python3.6.  Update networkx to match st2
-networkx>=2.5.1,<2.6; python_version < '3.7'
-networkx>=2.6,<3; python_version >= '3.7'
+networkx==3.2.1
 python-dateutil
 PyYAML>=3.1.0 # MIT
 six>=1.9.0


### PR DESCRIPTION
Drop Python 3.6 and Update Dependencies to newest versions. For ST2 3.9. 