### PR TITLE
Use hacking fork as dependency and align modules with stackstorm core.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,14 +1,9 @@
 [MESSAGES CONTROL]
 # C0111 Missing docstring 
 # I0011 Warning locally suppressed using disable-msg
-# I0012 Warning locally suppressed using disable-msg
-# W0704 Except doesn't do anything Used when an except clause does nothing but "pass" and there is no "else" clause
-# W0142 Used * or * magic* Used when a function or method is called using *args or **kwargs to dispatch arguments.
 # W0212 Access to a protected member %s of a client class
-# W0232 Class has no __init__ method Used when a class has no __init__ method, neither its parent classes.
 # W0613 Unused argument %r Used when a function or method argument is not used.
 # W0702 No exception's type specified Used when an except clause doesn't specify exceptions type to catch.
-# R0201 Method could be a function
 # W0614 Unused import XYZ from wildcard import
 # R0914 Too many local variables
 # R0912 Too many branches
@@ -16,7 +11,7 @@
 # R0913 Too many arguments
 # R0904 Too many public methods
 # E0211: Method has no argument
-disable=C0103,C0111,I0011,I0012,W0704,W0142,W0212,W0232,W0613,W0702,R0201,W0614,R0914,R0912,R0915,R0913,R0904,R0801
+disable=C0103,C0111,I0011,W0212,W0613,W0702,W0614,R0914,R0912,R0915,R0913,R0904,R0801
 
 [TYPECHECK]
 # Note: This modules are manipulated during the runtime so we can't detect all the properties during

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Changed
+~~~~~~~
+* Dropped python3.6 support.
+  Contributed by @nzlosh
+* Use pip 24.0 in virtualenv
+  Contributed by @nzlosh
+* Aligned pinned dependencies with St2 core.
+  Contributed by @nzlosh
+
+Fixed
+~~~~~
+
+
 1.6.0
 -----
 
@@ -159,7 +175,7 @@ Added
 ~~~~~
 
 * Add flake8 extension to restrict import alias. (improvement)
-* Add developer docs on getting started, testing, and StackStorm integration. (improvement) 
+* Add developer docs on getting started, testing, and StackStorm integration. (improvement)
 
 Changed
 ~~~~~~~
@@ -189,7 +205,7 @@ Added
 Fixed
 ~~~~~
 
-* Add sleep in while loop for composing execution graph to spread out cpu spike. (improvement) 
+* Add sleep in while loop for composing execution graph to spread out cpu spike. (improvement)
 * Value in quotes in shorthand publish should be evaluated as string type. Fixes #130 (bug fix)
 * Fix interpretation of boolean value in shorthand format of publish. Fixes #119 (bug fix)
 * Update YAQL section in docs on use of "=>" for named parameters in function calls. Closes #124

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,3 @@
-# Different versions of tox are required by python version
 tox-gh-actions
-tox==3.28.0 ; python_version == "3.6"
-tox==4.11.3; python_version >= "3.8"
+tox==4.11.3
+wheel

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
-sphinx>=2.0
+# 202404: Align all requirements with st2 test-requirements
+sphinx>=5.0.0,<7.2.0
 sphinx-autobuild
 sphinx_rtd_theme

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,12 @@
-black
-coverage
-flake8<3.9.0,>=3.8.0
-hacking
-mock>=1.0
-pytest
-pytest-cov
-pep8>=1.6.0,<1.7
-pylint>=2.5.2,<2.6
+# 202404: Align all requirements with st2 test-requirements
+coverage==7.2.7
+black==22.3.0
+flake8==7.0.0
+mock==4.0.3
+pytest==6.2.5
+pytest-cov==4.1.0
+pep8==1.7.1
+pylint==3.1.0
 twine
-unittest2
+# 202404: Use forked version for flake8 v7.0.0 to align requirements with st2 test-requirements
+hacking @ git+https://github.com/nzlosh/hacking@flake8v7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,15 @@
 # 202404: Align all requirements with st2 fixed-requirements
-chardet==5.2.0
-eventlet==0.35.2
-jinja2==3.1.3 # BSD License (3 clause)
-jsonschema==3.2.0 # MIT
+# 202405: Orquesta is a library, leave version ranges as wide as possible
+#         so pip can handle resolving the final version constraints.
+chardet>=3.0.2
+eventlet
+jinja2>=2.11 # BSD License (3 clause)
+jsonschema>=3,<4 # MIT
 # networkx v3.2 and greater does not support Python3.8.
-networkx<3.2
-python-dateutil==2.8.1
-pyyaml==5.3.1 # MIT
-six~=1.15
+networkx>=2.6,<3.2
+python-dateutil
+pyyaml>=5.3.1 # MIT
+six>=1.14.0
 stevedore>=1.3.0 # Apache-2.0
 ujson>=1.35 # BSD License
 yaql>=1.1.0 # Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-chardet>=3.0.2,<4.0.0
-eventlet
-Jinja2>=2.11 # BSD License (3 clause)
-jsonschema!=2.5.0,>=2.0.0,<=3.2 # MIT
-# networkx v2.6 does not support Python3.6.  Update networkx to match st2
-networkx>=2.5.1,<2.6; python_version < '3.7'
-networkx>=2.6,<3; python_version >= '3.7'
-python-dateutil
-PyYAML>=3.1.0 # MIT
-six>=1.9.0
+# 202404: Align all requirements with st2 fixed-requirements
+chardet==5.2.0
+eventlet==0.35.2
+jinja2==3.1.3 # BSD License (3 clause)
+jsonschema==3.2.0 # MIT
+# networkx v3.2 and greater does not support Python3.8.
+networkx<3.2
+python-dateutil==2.8.1
+pyyaml==5.3.1 # MIT
+six~=1.15
 stevedore>=1.3.0 # Apache-2.0
 ujson>=1.35 # BSD License
 yaql>=1.1.0 # Apache-2.0

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,11 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     entry_points={
         "orquesta.composers": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py36,py38,py39,py310,py311,pep8,docs
+envlist = py38,py39,py310,py311,pep8,docs
 minversion = 1.6
 skipsdist = True
 
 [gh-actions]
 python =
-    3.6: py36
     3.8: py38,pep8,docs
     3.9: py39
     3.10: py310


### PR DESCRIPTION
This set of patches is required as part of the updates needed to support py3.8, py3.9 and py3.10.  This PR is a blocking dependency for https://github.com/StackStorm/st2/pull/6157