### PR TITLE
Update rehearsing.py to disable limit of output errors during workflow testing.

### DIFF
--- a/orquesta/rehearsing.py
+++ b/orquesta/rehearsing.py
@@ -264,6 +264,7 @@ class WorkflowRehearsal(unittest.TestCase):
                 "The session object is not type of WorkflowTestCase or WorkflowRerunTestCase."
             )
 
+        self.maxDiff = None
         self.session = session
         self.inspection_errors = {}
         self.rerun = False


### PR DESCRIPTION
During usage you would before see something to the effect of:

```bash
2024-04-16 00:00:00,000 - ERROR - {'context': [{'type': 'jinja', 'expression[2500 chars]t'}]} != {}
Diff is 4500 characters long. Set self.maxDiff to None to see it.
```

This change will make it so that that error no longer shows up.